### PR TITLE
Fix Firefox storage persistence (#16) and new-tab dark-mode flash (#18)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,6 +4,7 @@
   "version": "1.3.0",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
+  "permissions": ["storage"],
   "icons": {
     "16": "icons/icon_16.png",
     "32": "icons/icon_32.png",

--- a/src/store.js
+++ b/src/store.js
@@ -7,28 +7,68 @@ export const THEME_KEYS = ["bg", "label", "count", "accent"];
 
 const DEFAULTS = { version: 1, birth: null, theme: null };
 
-/**
- * Load persisted state, applying defaults and migrating legacy (v1.2) storage.
- * @returns {{ version: number, birth: string|null, theme: Record<string,string>|null }}
- */
-export function load() {
-  let state;
+// Extension storage.local persists across the privacy/history clearing that can
+// silently wipe localStorage on extension pages (Firefox especially, issue #16).
+// Promise-based in Firefox (browser.*) and Chrome/Edge MV3 (chrome.*, 88+).
+const storage = (globalThis.browser ?? globalThis.chrome).storage.local;
+
+/** Read any pre-storage data still sitting in localStorage, or null. */
+function readLegacy() {
   try {
-    state = { ...DEFAULTS, ...JSON.parse(localStorage.getItem(KEY) || "{}") };
+    const raw = localStorage.getItem(KEY);
+    if (raw) return JSON.parse(raw);
   } catch {
-    state = { ...DEFAULTS };
+    // ignore malformed JSON
   }
-  // Migrate the old published format (localStorage.dob = "YYYY-MM-DD").
-  if (!state.birth && localStorage.dob) {
-    state.birth = localStorage.dob;
-    save(state);
+  try {
+    // The old published format stored the birthday as localStorage.dob.
+    const dob = localStorage.getItem("dob");
+    if (dob) return { birth: dob };
+  } catch {
+    // ignore inaccessible localStorage
   }
-  return state;
+  return null;
+}
+
+/** Drop migrated legacy keys so they can't shadow future reads. */
+function clearLegacy() {
+  try {
+    localStorage.removeItem(KEY);
+    localStorage.removeItem("dob");
+  } catch {
+    // ignore inaccessible localStorage
+  }
+}
+
+/**
+ * Load persisted state, applying defaults and migrating older localStorage data
+ * (the "mortality" JSON blob or the legacy "dob" string) on first run.
+ * @returns {Promise<{ version: number, birth: string|null, theme: Record<string,string>|null }>}
+ */
+export async function load() {
+  let stored;
+  try {
+    stored = (await storage.get(KEY))[KEY];
+  } catch {
+    stored = null;
+  }
+
+  if (!stored) {
+    const legacy = readLegacy();
+    if (legacy) {
+      const migrated = { ...DEFAULTS, ...legacy };
+      await save(migrated);
+      clearLegacy();
+      return migrated;
+    }
+  }
+
+  return { ...DEFAULTS, ...(stored || {}) };
 }
 
 /** Persist state. */
-export function save(state) {
-  localStorage.setItem(KEY, JSON.stringify(state));
+export async function save(state) {
+  await storage.set({ [KEY]: state });
 }
 
 /** Current effective value of a --<key> CSS custom property (hex). */

--- a/src/tab.html
+++ b/src/tab.html
@@ -3,7 +3,30 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <title>New Tab</title>
+    <!--
+      Critical background, inlined so the correct backdrop paints before tab.css
+      loads. Without this the browser flashes its default (white) new-tab canvas
+      in dark mode (see issue #18). Values mirror :root in tab.css.
+    -->
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #222222;
+        }
+      }
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background-color: var(--bg);
+      }
+    </style>
     <link rel="stylesheet" href="tab.css" />
   </head>
 

--- a/src/tab.js
+++ b/src/tab.js
@@ -6,10 +6,8 @@ import { renderSetup, renderCounter, renderSettings } from "./views.js";
 const YEAR_MS = 31556900000; // milliseconds per year (preserved from v1.2)
 
 const app = document.getElementById("app");
-let state = load();
+let state;
 let timer = null;
-
-applyTheme(state.theme);
 
 function stopTimer() {
   if (timer) {
@@ -76,5 +74,11 @@ function showSettings() {
   );
 }
 
-if (state.birth) showCounter();
-else showSetup();
+async function init() {
+  state = await load();
+  applyTheme(state.theme);
+  if (state.birth) showCounter();
+  else showSetup();
+}
+
+init();


### PR DESCRIPTION
Triage of the open issues against the rebuilt zero-dependency `src/`, plus fixes for the two that are real, still-present bugs.

## #16 — Firefox loses the birthday at random
`store.js` persisted to `localStorage`, which the browser treats as site data and can wipe via privacy/history clearing (Firefox especially). Moved persistence to the extension `storage.local` API, which is built to survive that.

- `browser ?? chrome` keeps it promise-based on Firefox and Chrome/Edge MV3
- First run auto-migrates existing data — the `mortality` JSON blob **or** the legacy `dob` string — then clears the old keys
- `manifest.json` gains the `storage` permission; `tab.js` boots through an async `init()`

Closes #16

## #18 — White flash on new tab in dark mode
`color-scheme: light dark` lived only in the external `tab.css`, so the browser painted its default white canvas before the stylesheet loaded. Declared it up front via `<meta name="color-scheme">` and inlined the base background so the correct dark backdrop paints immediately.

Removes the flash for the default/dark case. A user with a *custom* background may still see the correct-shade default for a frame before their color applies (theme is applied by JS after async load) — no longer white.

Closes #18

## #28 — Zen browser — not included
Triaged as stale: Zen is a Firefox fork with its own new-tab handling, so "not working" is a configuration/support matter with no reproducible defect in this extension. Being handled separately with a setup reply, not a code change.

## Testing
- Exercised `load()`/`save()` with mocked `chrome.storage.local` + `localStorage`: fresh install, `dob` migration, JSON-blob migration (incl. theme), straight reads, and save round-trip all pass; legacy keys cleared after migration.
- `npx prettier@3.9.4 --check .` passes (the CI format gate).