### PR TITLE
Fix Firefox publish: don't wait for AMO approval

### DIFF
--- a/.github/skills/publish-to-stores/SKILL.md
+++ b/.github/skills/publish-to-stores/SKILL.md
@@ -112,5 +112,9 @@ When asked to publish a release to the stores:
   confirm visibility, then retry.
 - **Firefox "add-on not found" / creates a new listing** — set
   `FIREFOX_ADDON_ID` to the existing add-on's id so the update targets it.
+- **Firefox run hangs / times out "waiting for approval"** — listed versions
+  need Mozilla's human review (days), so the workflow passes
+  `--approval-timeout=0`: `web-ext sign` returns as soon as the version is
+  submitted. The signed XPI appears on the add-on's Versions page once approved.
 - **Dry run** — locally, `bash scripts/publish.sh <store> --zip <file>
 --dry-run` authenticates and uploads without the final publish.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -209,7 +209,9 @@ PY
   fi
 
   log "Firefox: uploading & submitting to the listed channel"
-  npx --yes web-ext@8 sign --channel=listed "${args[@]}"
+  # --approval-timeout=0: return as soon as the version is submitted instead of
+  # blocking until Mozilla's human review approves it (which takes days).
+  npx --yes web-ext@8 sign --channel=listed --approval-timeout=0 "${args[@]}"
   rm -rf "$src"
   ok "Firefox: submitted $VERSION (review pending)"
 }


### PR DESCRIPTION
The v1.4.0 publish run submitted to all three stores, but the workflow reported failure because `web-ext sign --channel=listed` blocks in "Waiting for approval…" until Mozilla's human review approves the version (days), then times out after 15 min.

This passes `--approval-timeout=0` so `web-ext sign` returns as soon as the listed version is submitted, matching how Chrome/Edge already behave (submit → pending review). Also documents the behavior in the skill's troubleshooting.

No re-publish needed for v1.4.0 (already submitted to all three).