### PR TITLE
Fix Firefox add-on review warnings

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -1,0 +1,31 @@
+// Tiny DOM builder shared by the render code. Building nodes explicitly and
+// writing text via textContent keeps every user- or preset-derived value out of
+// an HTML parser: nothing is ever assigned to innerHTML, so no string can be
+// reinterpreted as markup (and Firefox's reviewer stops flagging unsafe
+// innerHTML assignments).
+
+/**
+ * Create an element.
+ * @param {string} tag  Element name.
+ * @param {Object<string, string|number|boolean|null|undefined>} [attrs]
+ *   Attributes to set. `class` maps to className; `true` adds a bare boolean
+ *   attribute; null/undefined/false are skipped. Everything else is set with
+ *   setAttribute (stringified), never parsed as HTML.
+ * @param {(Node|string)|(Node|string)[]} [children]  Text and/or nodes to
+ *   append. Strings become text nodes, so they can't inject markup.
+ * @returns {HTMLElement}
+ */
+export function el(tag, attrs = {}, children = []) {
+  const node = document.createElement(tag);
+  for (const [name, value] of Object.entries(attrs)) {
+    if (value == null || value === false) continue;
+    if (name === "class") node.className = value;
+    else if (value === true) node.setAttribute(name, "");
+    else node.setAttribute(name, String(value));
+  }
+  for (const child of Array.isArray(children) ? children : [children]) {
+    if (child == null) continue;
+    node.append(child);
+  }
+  return node;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,13 @@
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "permissions": ["storage"],
+  "browser_specific_settings": {
+    "gecko": {
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
+    }
+  },
   "icons": {
     "16": "icons/icon_16.png",
     "32": "icons/icon_32.png",

--- a/src/tab.js
+++ b/src/tab.js
@@ -10,6 +10,7 @@ import {
   PRESETS,
 } from "./store.js";
 import { renderSetup, renderCounter, renderSettings } from "./views.js";
+import { el } from "./dom.js";
 
 const YEAR_MS = 31556900000; // milliseconds per year (preserved from v1.2)
 const DAY_MS = 86400000;
@@ -100,12 +101,18 @@ function showCounter() {
 
   function layout() {
     els.label.textContent = LABELS[mode];
-    els.count.innerHTML =
-      mode === "years"
-        ? '<span class="int">0</span><span class="sep">.</span><span class="fraction" aria-hidden="true">0</span>'
-        : '<span class="int">0</span>';
-    intEl = els.count.querySelector(".int");
-    fracEl = els.count.querySelector(".fraction");
+    intEl = el("span", { class: "int" }, "0");
+    if (mode === "years") {
+      fracEl = el("span", { class: "fraction", "aria-hidden": "true" }, "0");
+      els.count.replaceChildren(
+        intEl,
+        el("span", { class: "sep" }, "."),
+        fracEl,
+      );
+    } else {
+      fracEl = null;
+      els.count.replaceChildren(intEl);
+    }
     lastInt = null;
   }
 

--- a/src/views.js
+++ b/src/views.js
@@ -1,7 +1,8 @@
-// Pure render functions for each screen. They write markup and wire events
-// to the callbacks provided by the controller (tab.js).
+// Pure render functions for each screen. They build DOM and wire events to the
+// callbacks provided by the controller (tab.js).
 
 import { THEME_KEYS, cssDefault, PRESETS } from "./store.js";
+import { el } from "./dom.js";
 
 const COLOR_LABELS = {
   bg: "Background",
@@ -18,18 +19,25 @@ function splitBirth(value) {
 
 /** Birthday entry screen. `current` pre-fills the fields when editing. */
 export function renderSetup(app, { start }, current) {
-  app.innerHTML = `
-    <form>
-      <h1 class="screen-title">When were you born?</h1>
-      <footer>
-        <input type="date" id="birth-date" aria-label="Date of birth" autocomplete="bday" required />
-        <input type="time" id="birth-time" aria-label="Time of birth (optional)" />
-        <button id="start">Start</button>
-      </footer>
-    </form>`;
-  const form = app.querySelector("form");
-  const dateEl = app.querySelector("#birth-date");
-  const timeEl = app.querySelector("#birth-time");
+  const dateEl = el("input", {
+    type: "date",
+    id: "birth-date",
+    "aria-label": "Date of birth",
+    autocomplete: "bday",
+    required: true,
+  });
+  const timeEl = el("input", {
+    type: "time",
+    id: "birth-time",
+    "aria-label": "Time of birth (optional)",
+  });
+  const startBtn = el("button", { id: "start" }, "Start");
+  const form = el("form", {}, [
+    el("h1", { class: "screen-title" }, "When were you born?"),
+    el("footer", {}, [dateEl, timeEl, startBtn]),
+  ]);
+  app.replaceChildren(form);
+
   if (current) {
     const [date, time] = splitBirth(current);
     dateEl.value = date;
@@ -46,8 +54,8 @@ export function renderSetup(app, { start }, current) {
     event.preventDefault();
     submitBirth();
   });
-  [dateEl, timeEl].forEach((el) =>
-    el.addEventListener("keydown", (event) => {
+  [dateEl, timeEl].forEach((input) =>
+    input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
         event.preventDefault();
         submitBirth();
@@ -59,22 +67,39 @@ export function renderSetup(app, { start }, current) {
 
 /** Live age counter. Returns the elements the ticker updates. */
 export function renderCounter(app, { openSettings, onCycle }, { born }) {
-  app.innerHTML = `
-    <button class="gear" id="gear" title="Settings" aria-label="Settings">&#9881;</button>
-    <div class="counter">
-      <h1 class="age-label" id="unit-label">Age</h1>
-      <p class="count" id="count" role="button" tabindex="0"
-         aria-label="Change units" title="Click to change units"></p>
-      <div class="meta">
-        <div class="progress" aria-hidden="true"><span class="progress-fill" id="progress-fill"></span></div>
-        <div class="meta-row">
-          <span class="born">${born}</span>
-          <span class="pct" id="pct"></span>
-        </div>
-      </div>
-    </div>`;
-  app.querySelector("#gear").addEventListener("click", openSettings);
-  const count = app.querySelector("#count");
+  const gear = el(
+    "button",
+    { class: "gear", id: "gear", title: "Settings", "aria-label": "Settings" },
+    "\u2699",
+  );
+  const label = el("h1", { class: "age-label", id: "unit-label" }, "Age");
+  const count = el("p", {
+    class: "count",
+    id: "count",
+    role: "button",
+    tabindex: "0",
+    "aria-label": "Change units",
+    title: "Click to change units",
+  });
+  const progressFill = el("span", {
+    class: "progress-fill",
+    id: "progress-fill",
+  });
+  const pct = el("span", { class: "pct", id: "pct" });
+  const counter = el("div", { class: "counter" }, [
+    label,
+    count,
+    el("div", { class: "meta" }, [
+      el("div", { class: "progress", "aria-hidden": "true" }, progressFill),
+      el("div", { class: "meta-row" }, [
+        el("span", { class: "born" }, born),
+        pct,
+      ]),
+    ]),
+  ]);
+  app.replaceChildren(gear, counter);
+
+  gear.addEventListener("click", openSettings);
   count.addEventListener("click", onCycle);
   count.addEventListener("keydown", (event) => {
     if (event.key === "Enter" || event.key === " ") {
@@ -82,79 +107,93 @@ export function renderCounter(app, { openSettings, onCycle }, { born }) {
       onCycle();
     }
   });
-  return {
-    label: app.querySelector("#unit-label"),
-    count,
-    progressFill: app.querySelector("#progress-fill"),
-    pct: app.querySelector("#pct"),
-  };
+  return { label, count, progressFill, pct };
 }
 
 /** Settings screen: presets + colour pickers + life expectancy + resets. */
 export function renderSettings(app, actions, { theme, expectancy }) {
-  const rows = THEME_KEYS.map(
-    (key) => `
-      <div class="row">
-        <label for="color-${key}">${COLOR_LABELS[key]}</label>
-        <input type="color" id="color-${key}" value="${
-          (theme && theme[key]) || cssDefault(key)
-        }" />
-      </div>`,
-  ).join("");
+  const colorInputs = {};
+  const rows = THEME_KEYS.map((key) => {
+    const input = el("input", {
+      type: "color",
+      id: `color-${key}`,
+      value: (theme && theme[key]) || cssDefault(key),
+    });
+    colorInputs[key] = input;
+    return el("div", { class: "row" }, [
+      el("label", { for: `color-${key}` }, COLOR_LABELS[key]),
+      input,
+    ]);
+  });
 
-  const swatches = Object.entries(PRESETS)
-    .map(
-      ([name, preset]) => `
-      <button type="button" class="preset" data-preset="${name}"
-              title="${name}" aria-label="${name} theme" style="background:${preset.bg}">
-        <i style="background:${preset.count}"></i><i style="background:${preset.accent}"></i>
-      </button>`,
-    )
-    .join("");
+  const swatches = Object.entries(PRESETS).map(([name, preset]) =>
+    el(
+      "button",
+      {
+        type: "button",
+        class: "preset",
+        "data-preset": name,
+        title: name,
+        "aria-label": `${name} theme`,
+        style: `background:${preset.bg}`,
+      },
+      [
+        el("i", { style: `background:${preset.count}` }),
+        el("i", { style: `background:${preset.accent}` }),
+      ],
+    ),
+  );
 
-  app.innerHTML = `
-    <div class="settings">
-      <h1 class="screen-title">Settings</h1>
-      <p class="settings-label">Presets</p>
-      <div class="presets">${swatches}</div>
-      <p class="settings-label">Colors</p>
-      ${rows}
-      <p class="settings-label">Memento mori</p>
-      <div class="row">
-        <label for="expectancy">Life expectancy (years)</label>
-        <input type="number" id="expectancy" min="1" max="150" step="1" value="${expectancy}" />
-      </div>
-      <div class="actions">
-        <button id="reset-birthday" class="btn-secondary">Change birthday</button>
-        <button id="reset-colors" class="btn-secondary">Reset colors</button>
-      </div>
-      <div class="actions">
-        <button id="done">Done</button>
-      </div>
-    </div>`;
+  const expectancyInput = el("input", {
+    type: "number",
+    id: "expectancy",
+    min: "1",
+    max: "150",
+    step: "1",
+    value: expectancy,
+  });
+  const resetBirthdayBtn = el(
+    "button",
+    { id: "reset-birthday", class: "btn-secondary" },
+    "Change birthday",
+  );
+  const resetColorsBtn = el(
+    "button",
+    { id: "reset-colors", class: "btn-secondary" },
+    "Reset colors",
+  );
+  const doneBtn = el("button", { id: "done" }, "Done");
+
+  const settings = el("div", { class: "settings" }, [
+    el("h1", { class: "screen-title" }, "Settings"),
+    el("p", { class: "settings-label" }, "Presets"),
+    el("div", { class: "presets" }, swatches),
+    el("p", { class: "settings-label" }, "Colors"),
+    ...rows,
+    el("p", { class: "settings-label" }, "Memento mori"),
+    el("div", { class: "row" }, [
+      el("label", { for: "expectancy" }, "Life expectancy (years)"),
+      expectancyInput,
+    ]),
+    el("div", { class: "actions" }, [resetBirthdayBtn, resetColorsBtn]),
+    el("div", { class: "actions" }, [doneBtn]),
+  ]);
+  app.replaceChildren(settings);
 
   THEME_KEYS.forEach((key) => {
-    app
-      .querySelector(`#color-${key}`)
-      .addEventListener("input", (event) =>
-        actions.setColor(key, event.target.value),
-      );
+    colorInputs[key].addEventListener("input", (event) =>
+      actions.setColor(key, event.target.value),
+    );
   });
-  app.querySelectorAll(".preset").forEach((btn) => {
+  swatches.forEach((btn) => {
     btn.addEventListener("click", () =>
       actions.applyPreset(btn.dataset.preset),
     );
   });
-  app
-    .querySelector("#expectancy")
-    .addEventListener("input", (event) =>
-      actions.setExpectancy(event.target.value),
-    );
-  app
-    .querySelector("#reset-birthday")
-    .addEventListener("click", actions.resetBirthday);
-  app
-    .querySelector("#reset-colors")
-    .addEventListener("click", actions.resetColors);
-  app.querySelector("#done").addEventListener("click", actions.closeSettings);
+  expectancyInput.addEventListener("input", (event) =>
+    actions.setExpectancy(event.target.value),
+  );
+  resetBirthdayBtn.addEventListener("click", actions.resetBirthday);
+  resetColorsBtn.addEventListener("click", actions.resetColors);
+  doneBtn.addEventListener("click", actions.closeSettings);
 }


### PR DESCRIPTION
Resolves the four issues addons.mozilla.org flagged on submission.

## Changes

- **`manifest.json`** — Declare `browser_specific_settings.gecko.data_collection_permissions = { "required": ["none"] }`, stating the add-on collects no user data (soon-required for AMO). Placed so `scripts/publish.sh` still injects `gecko.id` alongside it at publish time via `setdefault`.
- **`dom.js`** (new) — A tiny `el()` helper that builds elements via `createElement`/`setAttribute` and writes text with `textContent` — nothing is ever assigned to `innerHTML`.
- **`views.js`** — Rewrote `renderSetup` / `renderCounter` / `renderSettings` to build DOM with `el()` instead of `app.innerHTML` (fixes the `views.js:62` and `views.js:115` warnings). Structure, ids, classes, and event wiring are unchanged.
- **`tab.js`** — Replaced the `els.count.innerHTML` ternary in `layout()` with `el()` + `replaceChildren` (fixes `tab.js:103`).

## Warnings addressed

- `data_collection_permissions` property missing (manifest.json)
- Unsafe assignment to innerHTML — tab.js:103
- Unsafe assignment to innerHTML — views.js:62
- Unsafe assignment to innerHTML — views.js:115

## Verification

- `web-ext lint --source-dir=src`: **0 warnings, 0 notices**. The only remaining item is the pre-existing `EXTENSION_ID_REQUIRED` error, which the publish pipeline resolves by injecting `FIREFOX_ADDON_ID`; with the id present, lint reports **0 errors / 0 warnings / 0 notices**.
- Prettier clean; JS syntax valid.
- A jsdom smoke test (29 assertions) confirmed all three screens render the correct DOM and every event handler fires, with no markup leaking through `textContent`.

No behavior changes — the rendered UI and interactions are identical.