### PR TITLE
Add CODEOWNERS to require maintainer review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners for alphabt/mortality
+#
+# Every pull request that changes a matched path requires an approving review
+# from a listed owner. "*" matches everything, so all changes need @alphabt's
+# review once "Require review from Code Owners" is enabled in branch protection.
+* @alphabt


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @alphabt` so every pull request requires an approving review from @alphabt specifically (once "Require review from Code Owners" is enabled on `master`).

This is step 1 of tightening branch protection for future contributors:

- **This PR** — adds the CODEOWNERS file.
- **Follow-up (repo settings, not file-based)** — enable "Require review from Code Owners" and mark `Prettier` + `Pre Release` as required status checks. Admin bypass (`enforce_admins: false`) stays on so the sole maintainer can still merge solo work.

Net effect going forward: outside contributions need a green CI run **and** @alphabt's code-owner approval; the maintainer retains admin override.
