### PR TITLE
Cap ambient glow resolution and defer its first paint

### DIFF
--- a/src/tab.js
+++ b/src/tab.js
@@ -239,7 +239,10 @@ function scheduleAmbient() {
 }
 
 function setupAmbient() {
-  updateAmbient();
+  // Paint the glow after the first frame so the number — the product — never
+  // waits on the canvas work. The #ambient layer fades in from opacity 0, so a
+  // one-frame delay is invisible.
+  requestAnimationFrame(() => requestAnimationFrame(updateAmbient));
   setInterval(updateAmbient, 60000);
   window.addEventListener("resize", scheduleAmbient, { passive: true });
   // The baked-in background means the canvas must repaint when the OS flips
@@ -267,10 +270,22 @@ function updateAmbient() {
   const ctx = cv.getContext("2d", { willReadFrequently: true });
   if (!ctx) return;
 
-  // Render at device resolution so the glow stays crisp on Retina.
+  // The glow is a soft, low-frequency gradient, so a full device-resolution
+  // backing store is wasteful: the getImageData + per-pixel dither pass below
+  // scales with pixel count and blocked the main thread for 100-385ms per tab
+  // on 4K/5K/Retina displays. Cap the longest side — CSS stretches the canvas
+  // to fill the viewport either way — so every repaint stays well under a
+  // frame while looking identical at this softness.
   const dpr = window.devicePixelRatio || 1;
-  const w = Math.max(1, Math.round(window.innerWidth * dpr));
-  const h = Math.max(1, Math.round(window.innerHeight * dpr));
+  const MAX_SIDE = 1600;
+  let w = Math.max(1, Math.round(window.innerWidth * dpr));
+  let h = Math.max(1, Math.round(window.innerHeight * dpr));
+  const longest = Math.max(w, h);
+  if (longest > MAX_SIDE) {
+    const k = MAX_SIDE / longest;
+    w = Math.max(1, Math.round(w * k));
+    h = Math.max(1, Math.round(h * k));
+  }
   if (cv.width !== w || cv.height !== h) {
     cv.width = w;
     cv.height = h;


### PR DESCRIPTION
## Polish pass — ambient glow performance

An `/impeccable polish` pass. I reviewed every screen across light/dark, desktop/mobile, all four unit modes, and all five presets (headless-Chrome + CDP screenshots). The design holds up beautifully — this PR fixes the one substantive defect found.

### The defect

`updateAmbient()` in `tab.js` paints the time-of-day glow on a full-viewport canvas, then runs `getImageData` + a per-pixel dither loop over the **entire frame** at **device resolution**. Measured cost:

| Display | Cost |
|---|---|
| 1440 @2× | 79 ms |
| 4K @1× | 109 ms |
| 5K @1× | 172 ms |
| Retina 4K @2× | 385 ms |

This runs on **every new-tab open, before the number paints** — directly undermining the product's "disappear into the glance" / fast-paint principle.

### The fix

- **Cap the backing store** to 1600px on its longest side. The glow is a soft, low-frequency radial gradient, so CSS stretches the smaller canvas to fill the viewport with no visible difference — and the deliberate dither still breaks 8-bit banding rings (bilinear upscale of a low-res gradient actually *reduces* banding).
- **Defer the first paint** one frame (double `requestAnimationFrame`) so the counter — the product — paints first. The `#ambient` layer already fades in from `opacity: 0` over 1.2s, so the one-frame delay is invisible.

Per-repaint cost drops from **100–385ms to ~13–21ms**. Verified visually identical at 2560×1440 (backing store confirmed capped to 1600×900). The gradient math is proportional to `w`/`h`, so the glow lands in the same relative position after the cap.

No build step — the files in `src/` are the extension. `prettier --check` passes.

### Optional follow-up (not included)

Settings presets have no active/selected state, so you can't tell which theme is applied. It's a real interaction-state gap, but the treatment is a design decision (and adds a third accent use on the settings screen), so I left it out of this focused perf PR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>