### PR TITLE
Anchor age to a fixed birth instant via a birthplace time zone

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,7 @@
 // Persistence + theming. No dependencies, runs directly in the browser.
 
+import { detectZone } from "./time.js";
+
 const KEY = "mortality";
 
 // Colors the user can customise. Each maps to a CSS custom property (--<key>).
@@ -46,6 +48,7 @@ export const PRESETS = {
 const DEFAULTS = {
   version: 1,
   birth: null,
+  birthZone: null,
   theme: null,
   expectancy: 80,
   mode: "years",
@@ -109,9 +112,27 @@ function clearLegacy() {
 }
 
 /**
+ * Lock the birth INSTANT for records saved before timezone support. Their birth
+ * was a bare wall-clock string whose age was computed by parsing it in the
+ * device's *current* local zone, so backfilling birthZone with the detected
+ * zone keeps today's displayed age identical while anchoring the instant — from
+ * now on it can't drift if the user travels. Returns the state unchanged (same
+ * reference) when there is nothing to backfill.
+ */
+function backfillZone(state) {
+  if (state.birth && !state.birthZone) {
+    return { ...state, birthZone: detectZone() };
+  }
+  return state;
+}
+
+/**
  * Load persisted state, applying defaults and migrating older localStorage data
- * (the "mortality" JSON blob or the legacy "dob" string) on first run.
- * @returns {Promise<{ version: number, birth: string|null, theme: Record<string,string>|null }>}
+ * (the "mortality" JSON blob or the legacy "dob" string) on first run. Records
+ * that predate timezone support get their birthZone backfilled with the
+ * detected zone (see backfillZone) so the birth instant is anchored going
+ * forward without changing the age shown today.
+ * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, mode: string }>}
  */
 export async function load() {
   let stored;
@@ -124,7 +145,7 @@ export async function load() {
   if (!stored) {
     const legacy = readLegacy();
     if (legacy) {
-      const migrated = { ...DEFAULTS, ...legacy };
+      const migrated = backfillZone({ ...DEFAULTS, ...legacy });
       await save(migrated);
       // Only clear localStorage when a real extension store now owns the data;
       // under the localStorage shim, KEY *is* the store we just wrote to.
@@ -133,7 +154,10 @@ export async function load() {
     }
   }
 
-  return { ...DEFAULTS, ...(stored || {}) };
+  const state = { ...DEFAULTS, ...(stored || {}) };
+  const backfilled = backfillZone(state);
+  if (backfilled !== state) await save(backfilled);
+  return backfilled;
 }
 
 /** Persist state. */

--- a/src/tab.css
+++ b/src/tab.css
@@ -253,7 +253,7 @@ button:active {
   filter: brightness(0.92);
 }
 
-:where(button, input):focus-visible {
+:where(button, input, select):focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 2px;
 }
@@ -263,6 +263,52 @@ footer {
   display: flex;
   flex-direction: row;
   justify-content: center;
+}
+
+/* Setup: the birthplace time-zone picker sits under the date/time row so the
+   birth instant is anchored to where you were born, not where you are now. */
+.setup-row {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding-top: 0.5rem;
+}
+
+.setup-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-width: 22rem;
+  margin: 1rem auto 0;
+  text-align: left;
+}
+
+.setup-label {
+  color: var(--label);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.setup-field select {
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: var(--input-text);
+  background-color: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.hint {
+  margin: 0;
+  color: var(--label);
+  font-size: 0.8rem;
+  line-height: 1.45;
 }
 
 /* Settings */

--- a/src/tab.js
+++ b/src/tab.js
@@ -10,6 +10,7 @@ import {
   PRESETS,
 } from "./store.js";
 import { renderSetup, renderCounter, renderSettings } from "./views.js";
+import { birthInstantMs, detectZone, parseBirthParts } from "./time.js";
 import { el } from "./dom.js";
 
 const YEAR_MS = 31556900000; // milliseconds per year (preserved from v1.2)
@@ -51,16 +52,20 @@ export function clampExpectancy(value) {
 }
 
 export function formatBorn(birth) {
-  const date = new Date(birth);
-  if (Number.isNaN(date.getTime())) return "";
+  const parts = parseBirthParts(birth);
+  if (!parts) return "";
   try {
+    // Format the wall-clock date exactly as entered by pinning it to UTC, so the
+    // "Born …" line never slips a day when the viewer's zone differs from the
+    // birth zone.
     return (
       "Born " +
       new Intl.DateTimeFormat(undefined, {
         day: "numeric",
         month: "long",
         year: "numeric",
-      }).format(date)
+        timeZone: "UTC",
+      }).format(Date.UTC(parts.year, parts.month - 1, parts.day))
     );
   } catch {
     return "";
@@ -70,11 +75,12 @@ export function formatBorn(birth) {
 function showSetup() {
   stopTimer();
   setScreen("setup");
-  renderSetup(app, { start }, state.birth);
+  renderSetup(app, { start }, state.birth, state.birthZone);
 }
 
-function start(birth) {
+function start(birth, zone) {
   state.birth = birth;
+  state.birthZone = zone || detectZone();
   save(state);
   showCounter();
 }
@@ -83,7 +89,9 @@ function showCounter() {
   stopTimer();
   setScreen("counter");
 
-  const bornMs = new Date(state.birth).getTime();
+  // Anchor the birth instant to the zone the user was born in (falling back to
+  // the device zone), so age is a fixed point that never shifts when they move.
+  const bornMs = birthInstantMs(state.birth, state.birthZone || detectZone());
   const expectancy = clampExpectancy(state.expectancy);
   let mode = MODES.includes(state.mode) ? state.mode : "years";
 

--- a/src/time.js
+++ b/src/time.js
@@ -1,0 +1,163 @@
+// Dependency-free timezone math. A birth is stored as a wall-clock string with
+// no offset ("1990-03-15T09:00"); `new Date(that)` would parse it in whatever
+// zone the *device* currently sits in, so the birth INSTANT — and therefore the
+// 9-decimal age — silently shifts when the user travels or emigrates. These
+// helpers anchor the instant to the zone the user was actually born in, using
+// only the built-in Intl database (DST and historical offsets included).
+
+// A small spread of common zones for the rare engine without
+// Intl.supportedValuesOf (pre-2022), so the setup picker still works.
+const FALLBACK_ZONES = [
+  "UTC",
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "America/Sao_Paulo",
+  "Europe/London",
+  "Europe/Paris",
+  "Europe/Berlin",
+  "Europe/Moscow",
+  "Africa/Cairo",
+  "Africa/Johannesburg",
+  "Asia/Dubai",
+  "Asia/Kolkata",
+  "Asia/Bangkok",
+  "Asia/Shanghai",
+  "Asia/Singapore",
+  "Asia/Tokyo",
+  "Australia/Sydney",
+  "Pacific/Auckland",
+];
+
+/**
+ * Milliseconds `timeZone` is ahead of UTC at the given instant (positive east
+ * of UTC). Formats the instant *in the zone*, reads the wall-clock components
+ * back, and treats them as if they were UTC — the difference is the offset. Any
+ * DST/historical shift is captured because it asks the zone at that exact time.
+ * @param {number} utcMs Absolute time (ms since epoch).
+ * @param {string} timeZone IANA zone id, e.g. "Asia/Tokyo".
+ * @returns {number}
+ */
+export function zoneOffsetMsAt(utcMs, timeZone) {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const p = Object.fromEntries(
+    dtf.formatToParts(new Date(utcMs)).map((x) => [x.type, x.value]),
+  );
+  const asIfUtc = Date.UTC(
+    +p.year,
+    +p.month - 1,
+    +p.day,
+    +p.hour,
+    +p.minute,
+    +p.second,
+  );
+  return asIfUtc - utcMs;
+}
+
+/**
+ * Absolute UTC instant (ms) for a wall-clock date/time interpreted *in*
+ * `timeZone`. Two-pass: guess with a naive UTC assembly, correct by the zone's
+ * real offset, then re-check in case that correction crossed a DST boundary.
+ * @returns {number}
+ */
+export function zonedWallClockToUtcMs(y, mo, d, h, mi, timeZone) {
+  const guess = Date.UTC(y, mo - 1, d, h, mi);
+  const off1 = zoneOffsetMsAt(guess, timeZone);
+  let utc = guess - off1;
+  const off2 = zoneOffsetMsAt(utc, timeZone);
+  if (off2 !== off1) utc = guess - off2;
+  return utc;
+}
+
+/**
+ * Split a stored birth string ("YYYY-MM-DD" or "YYYY-MM-DDTHH:mm") into numeric
+ * parts. Returns null for anything malformed. We parse the digits ourselves so
+ * the value is never handed to `new Date`, which would reinterpret it in the
+ * viewer's local zone.
+ * @param {unknown} birth
+ * @returns {{year:number,month:number,day:number,hour:number,minute:number}|null}
+ */
+export function parseBirthParts(birth) {
+  if (typeof birth !== "string") return null;
+  const m = birth.match(
+    /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::\d{2})?)?$/,
+  );
+  if (!m) return null;
+  const year = +m[1];
+  const month = +m[2];
+  const day = +m[3];
+  const hour = m[4] === undefined ? 0 : +m[4];
+  const minute = m[5] === undefined ? 0 : +m[5];
+  if (month < 1 || month > 12) return null;
+  if (day < 1 || day > 31) return null;
+  if (hour > 23 || minute > 59) return null;
+  return { year, month, day, hour, minute };
+}
+
+/** True when `zone` is an IANA id the runtime can actually resolve. */
+export function isValidZone(zone) {
+  if (typeof zone !== "string" || !zone) return false;
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: zone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Absolute birth instant (ms) for a stored birth string, interpreted in
+ * `timeZone`. Falls back to the detected zone if `timeZone` is missing or
+ * unresolvable; returns NaN when the birth string itself can't be parsed.
+ * @returns {number}
+ */
+export function birthInstantMs(birth, timeZone) {
+  const p = parseBirthParts(birth);
+  if (!p) return NaN;
+  const zone = isValidZone(timeZone) ? timeZone : detectZone();
+  return zonedWallClockToUtcMs(p.year, p.month, p.day, p.hour, p.minute, zone);
+}
+
+/** The device's current IANA zone (e.g. "Asia/Tokyo"), or "UTC" if unknown. */
+export function detectZone() {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * Every IANA zone the runtime knows, or the curated fallback list, as a sorted
+ * array. Any ids passed as `ensure` are guaranteed to appear (so the picker can
+ * always select the detected or previously-saved zone, even a legacy alias the
+ * runtime omits from its canonical list).
+ * @param {...string} ensure
+ * @returns {string[]}
+ */
+export function listTimeZones(...ensure) {
+  let zones;
+  try {
+    zones =
+      typeof Intl.supportedValuesOf === "function"
+        ? Intl.supportedValuesOf("timeZone")
+        : FALLBACK_ZONES.slice();
+  } catch {
+    zones = FALLBACK_ZONES.slice();
+  }
+  const set = new Set(zones);
+  for (const zone of ensure) {
+    if (zone) set.add(zone);
+  }
+  return [...set].sort();
+}

--- a/src/views.js
+++ b/src/views.js
@@ -2,6 +2,7 @@
 // callbacks provided by the controller (tab.js).
 
 import { THEME_KEYS, cssDefault, PRESETS } from "./store.js";
+import { listTimeZones, detectZone } from "./time.js";
 import { el } from "./dom.js";
 
 const COLOR_LABELS = {
@@ -17,8 +18,8 @@ function splitBirth(value) {
   return [date, time.slice(0, 5)];
 }
 
-/** Birthday entry screen. `current` pre-fills the fields when editing. */
-export function renderSetup(app, { start }, current) {
+/** Birthday entry screen. `current`/`savedZone` pre-fill the fields when editing. */
+export function renderSetup(app, { start }, current, savedZone) {
   const dateEl = el("input", {
     type: "date",
     id: "birth-date",
@@ -31,10 +32,34 @@ export function renderSetup(app, { start }, current) {
     id: "birth-time",
     "aria-label": "Time of birth (optional)",
   });
+  const detected = detectZone();
+  const selectedZone = savedZone || detected;
+  const zoneEl = el(
+    "select",
+    { id: "birth-zone" },
+    listTimeZones(selectedZone, detected).map((zone) =>
+      el("option", { value: zone }, zone),
+    ),
+  );
+  zoneEl.value = selectedZone;
   const startBtn = el("button", { id: "start" }, "Start");
   const form = el("form", {}, [
     el("h1", { class: "screen-title" }, "When were you born?"),
-    el("footer", {}, [dateEl, timeEl, startBtn]),
+    el("div", { class: "setup-row" }, [dateEl, timeEl]),
+    el("div", { class: "setup-field" }, [
+      el(
+        "label",
+        { class: "setup-label", for: "birth-zone" },
+        "Where were you born?",
+      ),
+      zoneEl,
+      el(
+        "p",
+        { class: "hint" },
+        "Defaults to your current time zone. Set it to where you were born so your age stays exact if you move.",
+      ),
+    ]),
+    el("footer", {}, [startBtn]),
   ]);
   app.replaceChildren(form);
 
@@ -48,13 +73,13 @@ export function renderSetup(app, { start }, current) {
       dateEl.reportValidity();
       return;
     }
-    start(`${dateEl.value}T${timeEl.value || "00:00"}`);
+    start(`${dateEl.value}T${timeEl.value || "00:00"}`, zoneEl.value);
   }
   form.addEventListener("submit", (event) => {
     event.preventDefault();
     submitBirth();
   });
-  [dateEl, timeEl].forEach((input) =>
+  [dateEl, timeEl, zoneEl].forEach((input) =>
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
         event.preventDefault();

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -130,6 +130,7 @@ describe("save / load with the localStorage fallback", () => {
     await expect(load()).resolves.toEqual({
       version: 1,
       birth: null,
+      birthZone: null,
       theme: null,
       expectancy: 80,
       mode: "years",
@@ -140,6 +141,7 @@ describe("save / load with the localStorage fallback", () => {
     const state = {
       version: 1,
       birth: "2000-01-01T06:30",
+      birthZone: "America/New_York",
       theme: { bg: "#111111", label: "#aaa", count: "#fff", accent: "#f00" },
       expectancy: 70,
       mode: "days",
@@ -149,13 +151,32 @@ describe("save / load with the localStorage fallback", () => {
   });
 
   it("merges stored partial state over the defaults", async () => {
-    await save({ birth: "1990-05-15T00:00" });
+    await save({ birth: "1990-05-15T00:00", birthZone: "Asia/Tokyo" });
     await expect(load()).resolves.toEqual({
       version: 1,
       birth: "1990-05-15T00:00",
+      birthZone: "Asia/Tokyo",
       theme: null,
       expectancy: 80,
       mode: "years",
+    });
+  });
+
+  it("backfills birthZone with the detected zone for pre-zone records", async () => {
+    const detected = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    await save({ birth: "1990-05-15T00:00" });
+    const result = await load();
+    expect(result.birthZone).toBe(detected);
+    // The backfill is persisted, so it stays stable on subsequent loads.
+    await expect(load()).resolves.toMatchObject({ birthZone: detected });
+  });
+
+  it("leaves birthZone null when there is no birth to anchor", async () => {
+    await save({ expectancy: 66 });
+    await expect(load()).resolves.toMatchObject({
+      birth: null,
+      birthZone: null,
+      expectancy: 66,
     });
   });
 
@@ -175,6 +196,7 @@ describe("save / load with the localStorage fallback", () => {
     await expect(load()).resolves.toEqual({
       version: 1,
       birth: null,
+      birthZone: null,
       theme: null,
       expectancy: 80,
       mode: "years",
@@ -195,6 +217,7 @@ describe("save / load with the localStorage fallback", () => {
     await expect(load()).resolves.toEqual({
       version: 1,
       birth: null,
+      birthZone: null,
       theme: null,
       expectancy: 80,
       mode: "years",
@@ -232,7 +255,11 @@ describe("save / load against extension storage", () => {
 
   it("load reads existing state from extension storage", async () => {
     storageMock.get.mockResolvedValue({
-      mortality: { birth: "1999-09-09T00:00", expectancy: 95 },
+      mortality: {
+        birth: "1999-09-09T00:00",
+        birthZone: "Europe/London",
+        expectancy: 95,
+      },
     });
     const store = await importFreshStore();
     const result = await store.load();
@@ -240,6 +267,7 @@ describe("save / load against extension storage", () => {
     expect(result).toEqual({
       version: 1,
       birth: "1999-09-09T00:00",
+      birthZone: "Europe/London",
       theme: null,
       expectancy: 95,
       mode: "years",
@@ -275,6 +303,7 @@ describe("save / load against extension storage", () => {
     await expect(store.load()).resolves.toEqual({
       version: 1,
       birth: null,
+      birthZone: null,
       theme: null,
       expectancy: 80,
       mode: "years",

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import {
+  zoneOffsetMsAt,
+  zonedWallClockToUtcMs,
+  parseBirthParts,
+  birthInstantMs,
+  isValidZone,
+  detectZone,
+  listTimeZones,
+} from "../src/time.js";
+
+const HOUR_MS = 3600000;
+
+describe("zoneOffsetMsAt", () => {
+  it("reports a fixed-offset zone's offset from UTC", () => {
+    const utcMs = Date.UTC(2021, 0, 1, 0, 0, 0);
+    expect(zoneOffsetMsAt(utcMs, "Asia/Tokyo")).toBe(9 * HOUR_MS);
+    expect(zoneOffsetMsAt(utcMs, "UTC")).toBe(0);
+  });
+
+  it("tracks daylight saving across the year", () => {
+    const winter = Date.UTC(2021, 0, 1, 12, 0, 0);
+    const summer = Date.UTC(2021, 6, 1, 12, 0, 0);
+    expect(zoneOffsetMsAt(winter, "America/New_York")).toBe(-5 * HOUR_MS);
+    expect(zoneOffsetMsAt(summer, "America/New_York")).toBe(-4 * HOUR_MS);
+  });
+});
+
+describe("zonedWallClockToUtcMs", () => {
+  it("anchors a wall clock to the correct absolute instant", () => {
+    expect(zonedWallClockToUtcMs(1990, 3, 15, 9, 0, "Asia/Tokyo")).toBe(
+      Date.parse("1990-03-15T09:00:00+09:00"),
+    );
+  });
+
+  it("uses the offset in effect at that historical date (DST-aware)", () => {
+    // Same wall clock, opposite sides of the DST switch → different instants.
+    expect(zonedWallClockToUtcMs(2021, 1, 1, 0, 0, "America/New_York")).toBe(
+      Date.parse("2021-01-01T00:00:00-05:00"),
+    );
+    expect(zonedWallClockToUtcMs(2021, 7, 1, 0, 0, "America/New_York")).toBe(
+      Date.parse("2021-07-01T00:00:00-04:00"),
+    );
+  });
+
+  it("differs from a naive local parse for a far-away zone", () => {
+    const tokyo = zonedWallClockToUtcMs(2000, 1, 1, 0, 0, "Asia/Tokyo");
+    const la = zonedWallClockToUtcMs(2000, 1, 1, 0, 0, "America/Los_Angeles");
+    // Midnight Jan 1 2000 is a different instant in Tokyo than in LA.
+    expect(la - tokyo).toBe(17 * HOUR_MS);
+  });
+});
+
+describe("parseBirthParts", () => {
+  it("parses a date+time string", () => {
+    expect(parseBirthParts("1990-03-15T09:00")).toEqual({
+      year: 1990,
+      month: 3,
+      day: 15,
+      hour: 9,
+      minute: 0,
+    });
+  });
+
+  it("parses a date-only string as midnight", () => {
+    expect(parseBirthParts("1985-07-20")).toEqual({
+      year: 1985,
+      month: 7,
+      day: 20,
+      hour: 0,
+      minute: 0,
+    });
+  });
+
+  it("returns null for malformed or out-of-range values", () => {
+    for (const value of ["", "not-a-date", "1990-13-01", "1990-05-32", null]) {
+      expect(parseBirthParts(value)).toBeNull();
+    }
+  });
+});
+
+describe("birthInstantMs", () => {
+  it("interprets the stored string in the given zone", () => {
+    expect(birthInstantMs("1990-03-15T09:00", "Asia/Tokyo")).toBe(
+      Date.parse("1990-03-15T09:00:00+09:00"),
+    );
+  });
+
+  it("returns NaN for an unparseable birth string", () => {
+    expect(Number.isNaN(birthInstantMs("nope", "Asia/Tokyo"))).toBe(true);
+  });
+
+  it("falls back to the detected zone when the zone is invalid", () => {
+    const detected = detectZone();
+    expect(birthInstantMs("2000-01-01T00:00", "Not/AZone")).toBe(
+      birthInstantMs("2000-01-01T00:00", detected),
+    );
+  });
+});
+
+describe("isValidZone", () => {
+  it("accepts resolvable IANA ids and rejects the rest", () => {
+    expect(isValidZone("Asia/Tokyo")).toBe(true);
+    expect(isValidZone("UTC")).toBe(true);
+    expect(isValidZone("Not/AZone")).toBe(false);
+    expect(isValidZone("")).toBe(false);
+    expect(isValidZone(null)).toBe(false);
+  });
+});
+
+describe("detectZone", () => {
+  it("returns a non-empty zone id", () => {
+    const zone = detectZone();
+    expect(typeof zone).toBe("string");
+    expect(zone.length).toBeGreaterThan(0);
+  });
+});
+
+describe("listTimeZones", () => {
+  it("returns a sorted list that includes common zones", () => {
+    const zones = listTimeZones();
+    expect(Array.isArray(zones)).toBe(true);
+    expect(zones).toContain("Asia/Tokyo");
+    expect([...zones].sort()).toEqual(zones);
+  });
+
+  it("guarantees any `ensure` ids appear exactly once", () => {
+    const zones = listTimeZones("Custom/Place", "Asia/Tokyo");
+    expect(zones).toContain("Custom/Place");
+    expect(zones.filter((z) => z === "Asia/Tokyo")).toHaveLength(1);
+  });
+});

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -43,20 +43,22 @@ describe("renderSetup", () => {
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "2000-03-04";
     app.querySelector("#birth-time").value = "09:15";
+    const zone = app.querySelector("#birth-zone").value;
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2000-03-04T09:15");
+    expect(start).toHaveBeenCalledWith("2000-03-04T09:15", zone);
   });
 
   it("defaults an empty time to midnight", () => {
     const start = vi.fn();
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "2010-10-10";
+    const zone = app.querySelector("#birth-zone").value;
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2010-10-10T00:00");
+    expect(start).toHaveBeenCalledWith("2010-10-10T00:00", zone);
   });
 
   it("blocks submission and reports validity when the date is empty", () => {
@@ -75,8 +77,26 @@ describe("renderSetup", () => {
     const start = vi.fn();
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "1975-12-25";
+    const zone = app.querySelector("#birth-zone").value;
     keydown(app.querySelector("#birth-date"), "Enter");
-    expect(start).toHaveBeenCalledWith("1975-12-25T00:00");
+    expect(start).toHaveBeenCalledWith("1975-12-25T00:00", zone);
+  });
+
+  it("renders a birthplace time-zone select defaulting to the device zone", () => {
+    renderSetup(app, { start: vi.fn() }, null);
+    const zone = app.querySelector("#birth-zone");
+    expect(zone).not.toBeNull();
+    expect(zone.tagName).toBe("SELECT");
+    expect(zone.value).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    // The visible label is associated with the control for accessibility.
+    const label = app.querySelector('label[for="birth-zone"]');
+    expect(label).not.toBeNull();
+    expect(label.textContent).toBe("Where were you born?");
+  });
+
+  it("pre-selects the saved birth zone when editing", () => {
+    renderSetup(app, { start: vi.fn() }, "1990-05-15T00:00", "Asia/Tokyo");
+    expect(app.querySelector("#birth-zone").value).toBe("Asia/Tokyo");
   });
 });
 


### PR DESCRIPTION
## The bug

`birth` was stored as a wall-clock string with **no timezone** (e.g. `"1990-03-15T09:00"`). The counter computed the birth instant with `new Date(state.birth)`, which parses in the **device's current local zone**. So the birth *instant* — and with it the 9-decimal age and the day/week rollovers — silently shifted whenever the user travelled or emigrated (Tokyo to New York is ~14h of drift). For an extension whose whole aesthetic is nine decimals of precision, the anchor point has to be fixed.

## The fix: a fixed birth instant

- **State:** adds `birthZone` (an IANA zone id such as `"Asia/Tokyo"`, default `null`) persisted alongside `birth`.
- **New `src/time.js`** (dependency-free, built-in `Intl` only): a two-pass `zonedWallClockToUtcMs()` converts the stored wall-clock parts, *interpreted in `birthZone`*, to an absolute UTC instant — using the zone's **actual** offset at that historical date, so DST and historical offset changes are respected. The birth string is parsed by hand (`parseBirthParts`), never via `new Date`, so it can never be reinterpreted in the viewer's zone.
- **Setup UI:** a labeled **"Where were you born?"** `<select>`, populated from `Intl.supportedValuesOf('timeZone')` (with a small curated fallback), defaulting to the detected zone and pre-selecting the saved zone when editing. A short hint explains it defaults to your current zone and should be set to where you were born so your age stays exact if you move. Enter still submits.
- **`formatBorn`** now renders the date exactly **as entered** (pinned to UTC), so the "Born …" line never slips a day due to the viewer's zone.

## Migration (fixes existing users)

`load()` backfills `birthZone` with the **detected** zone for any stored record that has a `birth` but no `birthZone`, and persists it. Because the legacy local-parse used exactly the device's current zone, **today's displayed age is unchanged** — but the instant is now anchored, so it can't drift in the future. New setups always store the chosen zone.

## Constraints honoured

Zero dependencies, zero build, no new manifest permissions, `prefers-reduced-motion` unaffected, WCAG-friendly (visible `<label for>` on the select, focus ring extended to `select`). The new select is styled to match the existing date/time inputs.

## Verification

- `npm test` — **91 passing** (added `test/time.test.js`; updated store/views tests for the new state shape and the `start(birth, zone)` signature).
- `npm run format:check` passes; `node --check` passes on all modules.
- `zonedWallClockToUtcMs(1990,3,15,9,0,'Asia/Tokyo') === Date.parse('1990-03-15T09:00:00+09:00')`, and the migration reproduces the pre-change age exactly for an existing record.
