### PR TITLE
Add a calendar-exact age counter mode

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -8,7 +8,7 @@ const KEY = "mortality";
 export const THEME_KEYS = ["bg", "label", "count", "accent"];
 
 // Counter display units, cycled by clicking the number.
-export const MODES = ["years", "days", "weeks", "weeksLeft"];
+export const MODES = ["years", "calendar", "days", "weeks", "weeksLeft"];
 
 // Curated full-theme presets. Every set is contrast-checked (count & label ≥4.5:1
 // on bg, accent ≥3:1). Applying one writes all four THEME_KEYS at once.

--- a/src/tab.css
+++ b/src/tab.css
@@ -173,6 +173,27 @@ body.screen-counter #app {
   mask-image: linear-gradient(90deg, #000 0 60%, rgba(0, 0, 0, 0.28) 100%);
 }
 
+/* Calendar-age breakdown: full-size figures with small superscript units
+   (36 yr 3 mo 24 d), matching the counter's precise, tabular aesthetic. */
+.count .cal-num {
+  color: var(--count);
+}
+
+.count .cal-unit {
+  font-size: 0.32em;
+  font-weight: 500;
+  vertical-align: 0.95em;
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+  color: var(--label);
+  margin-left: 0.08em;
+  margin-right: 0.3em;
+}
+
+.count .cal-unit:last-child {
+  margin-right: 0;
+}
+
 /* Life-elapsed meter + editorial anchor line under the number. */
 .meta {
   margin-top: 1.15rem;

--- a/src/tab.js
+++ b/src/tab.js
@@ -10,7 +10,13 @@ import {
   PRESETS,
 } from "./store.js";
 import { renderSetup, renderCounter, renderSettings } from "./views.js";
-import { birthInstantMs, detectZone, parseBirthParts } from "./time.js";
+import {
+  birthInstantMs,
+  calendarAge,
+  detectZone,
+  isValidZone,
+  parseBirthParts,
+} from "./time.js";
 import { el } from "./dom.js";
 
 const YEAR_MS = 31556900000; // milliseconds per year (preserved from v1.2)
@@ -19,6 +25,7 @@ const WEEK_MS = 7 * DAY_MS;
 
 const LABELS = {
   years: "Age",
+  calendar: "Calendar age",
   days: "Days lived",
   weeks: "Weeks lived",
   weeksLeft: "Weeks left",
@@ -91,7 +98,9 @@ function showCounter() {
 
   // Anchor the birth instant to the zone the user was born in (falling back to
   // the device zone), so age is a fixed point that never shifts when they move.
-  const bornMs = birthInstantMs(state.birth, state.birthZone || detectZone());
+  // The same effective zone drives the calendar-age breakdown below.
+  const zone = isValidZone(state.birthZone) ? state.birthZone : detectZone();
+  const bornMs = birthInstantMs(state.birth, zone);
   const expectancy = clampExpectancy(state.expectancy);
   let mode = MODES.includes(state.mode) ? state.mode : "years";
 
@@ -106,22 +115,31 @@ function showCounter() {
   let lastInt = null;
   let lastPct = null;
   let lastFrac = -1;
+  let lastCal = null;
 
   function layout() {
     els.label.textContent = LABELS[mode];
-    intEl = el("span", { class: "int" }, "0");
-    if (mode === "years") {
-      fracEl = el("span", { class: "fraction", "aria-hidden": "true" }, "0");
-      els.count.replaceChildren(
-        intEl,
-        el("span", { class: "sep" }, "."),
-        fracEl,
-      );
-    } else {
+    if (mode === "calendar") {
+      intEl = null;
       fracEl = null;
-      els.count.replaceChildren(intEl);
+      // The y/m/d spans are (re)built in tick() whenever the value changes.
+      els.count.replaceChildren();
+    } else {
+      intEl = el("span", { class: "int" }, "0");
+      if (mode === "years") {
+        fracEl = el("span", { class: "fraction", "aria-hidden": "true" }, "0");
+        els.count.replaceChildren(
+          intEl,
+          el("span", { class: "sep" }, "."),
+          fracEl,
+        );
+      } else {
+        fracEl = null;
+        els.count.replaceChildren(intEl);
+      }
     }
     lastInt = null;
+    lastCal = null;
   }
 
   function cycle() {
@@ -158,7 +176,8 @@ function showCounter() {
   }
 
   function tick() {
-    const elapsed = Date.now() - bornMs;
+    const now = Date.now();
+    const elapsed = now - bornMs;
     const years = elapsed / YEAR_MS;
 
     if (mode === "years") {
@@ -169,6 +188,23 @@ function showCounter() {
         updateAria(whole + " years");
       }
       fracEl.textContent = fraction;
+    } else if (mode === "calendar") {
+      const { y, m, d } = calendarAge(bornMs, now, zone);
+      const key = `${y}|${m}|${d}`;
+      // Only rewrite the DOM when the y/m/d actually changes (days tick over at
+      // most once a day), so the node isn't rebuilt every 100ms.
+      if (key !== lastCal) {
+        els.count.replaceChildren(
+          el("span", { class: "cal-num" }, String(y)),
+          el("span", { class: "cal-unit" }, "yr"),
+          el("span", { class: "cal-num" }, String(m)),
+          el("span", { class: "cal-unit" }, "mo"),
+          el("span", { class: "cal-num" }, String(d)),
+          el("span", { class: "cal-unit" }, "d"),
+        );
+        lastCal = key;
+        updateAria(`${y} years ${m} months ${d} days`);
+      }
     } else {
       let value;
       if (mode === "days") value = Math.floor(elapsed / DAY_MS);

--- a/src/time.js
+++ b/src/time.js
@@ -65,6 +65,81 @@ export function zoneOffsetMsAt(utcMs, timeZone) {
 }
 
 /**
+ * Wall-clock calendar parts of a UTC instant as seen in `timeZone`. Reads the
+ * components straight from the Intl database (DST and historical offsets
+ * included) so the values match what a clock on the wall in that zone shows.
+ * @param {number} utcMs Absolute time (ms since epoch).
+ * @param {string} timeZone IANA zone id, e.g. "Asia/Tokyo".
+ * @returns {{year:number,month:number,day:number,hour:number,minute:number,second:number}}
+ */
+export function zonedParts(utcMs, timeZone) {
+  const dtf = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+  const p = Object.fromEntries(
+    dtf.formatToParts(new Date(utcMs)).map((x) => [x.type, x.value]),
+  );
+  return {
+    year: +p.year,
+    month: +p.month,
+    day: +p.day,
+    hour: +p.hour,
+    minute: +p.minute,
+    second: +p.second,
+  };
+}
+
+/** Number of days in a 1-based month, wrapping month 0 to the prior December. */
+function daysInMonth(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+/**
+ * True calendar age between two instants as whole years, months and days (e.g.
+ * `{y:36, m:3, d:24}`). BOTH instants are read in `timeZone` so the anniversary
+ * lines up with the birthplace and stays stable wherever the viewer sits.
+ *
+ * Borrow-based subtraction: when the day component is short of the birthday, we
+ * borrow the real length of the month preceding `nowMs`; when months go
+ * negative we borrow a year. The birth day is clamped into the (possibly
+ * shorter) borrowed month, so a birth on the 29th–31st can never push the day
+ * count negative when that month is short — e.g. born the 31st with February in
+ * between resolves to 1 day, not a negative.
+ * @param {number} birthInstantMs Absolute birth instant (ms since epoch).
+ * @param {number} nowMs Absolute current instant (ms since epoch).
+ * @param {string} timeZone IANA zone id the breakdown is evaluated in.
+ * @returns {{y:number,m:number,d:number}}
+ */
+export function calendarAge(birthInstantMs, nowMs, timeZone) {
+  const b = zonedParts(birthInstantMs, timeZone);
+  const n = zonedParts(nowMs, timeZone);
+
+  let y = n.year - b.year;
+  let m = n.month - b.month;
+  let d = n.day - b.day;
+
+  if (d < 0) {
+    m -= 1;
+    const prevMonthLen = daysInMonth(n.year, n.month - 1);
+    // Days elapsed since the birthday anniversary in that previous month, with
+    // the birth day clamped to the month's real length.
+    d = prevMonthLen - Math.min(b.day, prevMonthLen) + n.day;
+  }
+  if (m < 0) {
+    m += 12;
+    y -= 1;
+  }
+  return { y, m, d };
+}
+
+/**
  * Absolute UTC instant (ms) for a wall-clock date/time interpreted *in*
  * `timeZone`. Two-pass: guess with a naive UTC assembly, correct by the zone's
  * real offset, then re-check in case that correction crossed a DST boundary.

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -34,7 +34,7 @@ describe("constants", () => {
   });
 
   it("exposes the counter display modes", () => {
-    expect(MODES).toEqual(["years", "days", "weeks", "weeksLeft"]);
+    expect(MODES).toEqual(["years", "calendar", "days", "weeks", "weeksLeft"]);
   });
 
   it("every preset defines a hex value for every theme key", () => {

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -95,8 +95,15 @@ describe("counter interactions", () => {
     seed({ birth: "2000-01-01T00:00", mode: "years" });
     await boot();
 
+    // years -> calendar (the new mode inserted after years).
     document.querySelector("#count").click();
+    expect(document.querySelector("#unit-label").textContent).toBe(
+      "Calendar age",
+    );
+    expect(stored().mode).toBe("calendar");
 
+    // calendar -> days.
+    document.querySelector("#count").click();
     expect(document.querySelector("#unit-label").textContent).toBe(
       "Days lived",
     );
@@ -152,6 +159,28 @@ describe("counter interactions", () => {
       Math.round((80 * YEAR_MS - elapsed) / (7 * DAY_MS)),
     ).toLocaleString();
     expect(document.querySelector("#count .int").textContent).toBe(expected);
+  });
+
+  it("renders the calendar-age breakdown as number + unit spans", async () => {
+    // System clock is 2020-01-01 and the birth is 2000-01-01 (same wall-clock
+    // date twenty years apart), so the breakdown is exactly 20yr 0mo 0d.
+    seed({ birth: "2000-01-01T00:00", mode: "calendar" });
+    await boot();
+    expect(document.querySelector("#unit-label").textContent).toBe(
+      "Calendar age",
+    );
+
+    const nums = [...document.querySelectorAll("#count .cal-num")].map(
+      (n) => n.textContent,
+    );
+    const units = [...document.querySelectorAll("#count .cal-unit")].map(
+      (n) => n.textContent,
+    );
+    expect(nums).toEqual(["20", "0", "0"]);
+    expect(units).toEqual(["yr", "mo", "d"]);
+    expect(document.querySelector("#count").getAttribute("aria-label")).toBe(
+      "Calendar age 20 years 0 months 0 days. Activate to change units.",
+    );
   });
 });
 

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   zoneOffsetMsAt,
   zonedWallClockToUtcMs,
+  zonedParts,
+  calendarAge,
   parseBirthParts,
   birthInstantMs,
   isValidZone,
@@ -23,6 +25,79 @@ describe("zoneOffsetMsAt", () => {
     const summer = Date.UTC(2021, 6, 1, 12, 0, 0);
     expect(zoneOffsetMsAt(winter, "America/New_York")).toBe(-5 * HOUR_MS);
     expect(zoneOffsetMsAt(summer, "America/New_York")).toBe(-4 * HOUR_MS);
+  });
+});
+
+describe("zonedParts", () => {
+  it("reads a UTC instant's wall-clock parts in the given zone", () => {
+    const utcMs = Date.UTC(2021, 0, 1, 0, 30, 0); // 2021-01-01T00:30Z
+    expect(zonedParts(utcMs, "UTC")).toEqual({
+      year: 2021,
+      month: 1,
+      day: 1,
+      hour: 0,
+      minute: 30,
+      second: 0,
+    });
+    // Tokyo is +9h, so the same instant is 09:30 the same calendar day.
+    expect(zonedParts(utcMs, "Asia/Tokyo")).toMatchObject({
+      year: 2021,
+      month: 1,
+      day: 1,
+      hour: 9,
+      minute: 30,
+    });
+  });
+});
+
+describe("calendarAge", () => {
+  const at = (y, mo, d, h = 0, mi = 0) => Date.UTC(y, mo - 1, d, h, mi);
+
+  it("is whole years with zero months and days on a birthday", () => {
+    const birth = at(1990, 3, 15, 9, 0);
+    const now = at(2020, 3, 15, 9, 0);
+    expect(calendarAge(birth, now, "UTC")).toEqual({ y: 30, m: 0, d: 0 });
+  });
+
+  it("ignores the time of day within the anniversary date", () => {
+    const birth = at(1990, 3, 15, 9, 0);
+    // Earlier in the day than the birth time, but the same calendar date.
+    const now = at(2020, 3, 15, 1, 0);
+    expect(calendarAge(birth, now, "UTC")).toEqual({ y: 30, m: 0, d: 0 });
+  });
+
+  it("borrows from the previous month when the day is short", () => {
+    const birth = at(1990, 1, 20);
+    const now = at(2020, 3, 10);
+    // 30y to 2020-01-20, +1mo to 2020-02-20, then 9 days to end of Feb (leap,
+    // 29) + 10 into March = 19 days.
+    expect(calendarAge(birth, now, "UTC")).toEqual({ y: 30, m: 1, d: 19 });
+  });
+
+  it("borrows a year when the month is short", () => {
+    const birth = at(2000, 11, 10);
+    const now = at(2020, 2, 10);
+    expect(calendarAge(birth, now, "UTC")).toEqual({ y: 19, m: 3, d: 0 });
+  });
+
+  it("never yields a negative day for a 31st birth over a short month", () => {
+    const birth = at(2000, 1, 31);
+    const now = at(2021, 3, 1);
+    // Feb has no 31st: the clamp keeps this at 1 day, not a negative.
+    expect(calendarAge(birth, now, "UTC")).toEqual({ y: 21, m: 1, d: 1 });
+  });
+
+  it("evaluates both instants in the given zone", () => {
+    // Same two absolute instants, read in two zones. In Los Angeles (UTC-8) the
+    // "now" instant falls on the previous calendar day, so the breakdown differs.
+    const birth = Date.UTC(2000, 0, 1, 12, 0);
+    const now = Date.UTC(2020, 0, 1, 5, 0);
+    expect(calendarAge(birth, now, "UTC")).toEqual({ y: 20, m: 0, d: 0 });
+    expect(calendarAge(birth, now, "America/Los_Angeles")).toEqual({
+      y: 19,
+      m: 11,
+      d: 30,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a new **calendar** counter mode that shows the user's *true* calendar age as years / months / days (e.g. `36 yr 3 mo 24 d`), complementing — not replacing — the existing fractional `years` mode. Click/Enter/Space cycles into it right after `years`:

```
years -> calendar -> days -> weeks -> weeksLeft
```

Targets `master` (the birth-timezone work it built on landed via #38); the diff is only the calendar-age delta.

## How it works

- **`src/time.js`** — reuses the existing zone helpers. Adds `zonedParts(utcMs, tz)` (an instant's wall-clock parts via `Intl.DateTimeFormat.formatToParts`) and `calendarAge(birthInstantMs, nowMs, tz)` returning `{y, m, d}`. Both the birth and current instants are evaluated **in the effective birth zone** (`state.birthZone`, falling back to the detected zone), so the anniversary aligns to the birthplace and stays stable when the viewer travels. Borrow-based subtraction uses the previous month's real length and clamps the birth day, so a birth on the 29th–31st can never produce a negative day.
- **`src/store.js`** — `"calendar"` inserted into `MODES` right after `"years"`.
- **`src/tab.js`** — new `LABELS.calendar = "Calendar age"`; the effective zone is computed once and drives both the birth instant and the breakdown. `layout()` and `tick()` gain a calendar branch that renders distinct `.cal-num` / `.cal-unit` spans and only rewrites the DOM when the y/m/d value changes. `updateAria()` announces e.g. *"Calendar age 36 years 3 months 24 days"*. The fractional `years` branch and the days/weeks/weeksLeft branches are untouched; the progress meter and `%` line stay based on fractional years.
- **`src/tab.css`** — `.cal-num` (uses `--count`) and superscripted, lowercased `.cal-unit` (uses `--label`), matching the counter's precise numeric aesthetic.

## Constraints honored

Zero dependencies, zero build, `Intl`-only, no new permissions. Accessibility preserved (keyboard cycling + aria).

## Tests

`npm test` → **99 passing**. Added `calendarAge` / `zonedParts` unit tests (exact birthday, day-borrow, month-borrow, 31st-over-February clamp, zone sensitivity) and a calendar-mode integration test. Updated the two existing tests affected by the new mode (MODES constant + cycle order). `npm run format:check` clean; `node --check` clean.
