### PR TITLE
Refine setup, counter, and settings UX

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -192,7 +192,7 @@ function luminance(hex) {
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
-function contrast(a, b) {
+export function contrast(a, b) {
   const la = luminance(a),
     lb = luminance(b);
   return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);

--- a/src/tab.css
+++ b/src/tab.css
@@ -153,6 +153,28 @@ body.screen-counter #app {
   outline-offset: 8px;
 }
 
+/* Discoverability hint for the click-to-cycle affordance: hidden until the
+   number is hovered or focused, so it never competes with the count itself. */
+.unit-hint {
+  margin: 0.4rem 0 0;
+  color: var(--label);
+  font-size: 0.72rem;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+}
+
+.count:hover ~ .unit-hint,
+.count:focus-visible ~ .unit-hint {
+  opacity: 1;
+}
+
+.unit-hint + .meta {
+  margin-top: 0.6rem;
+}
+
 .count .sep {
   color: var(--accent);
 }
@@ -332,6 +354,28 @@ footer {
   line-height: 1.45;
 }
 
+.screen-subtitle {
+  margin: -0.5rem 0 1.25rem;
+  color: var(--label);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.setup-hint {
+  margin-top: 0.5rem;
+  text-align: center;
+}
+
+.field-error {
+  margin: 0.5rem 0 0;
+  color: var(--count);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  text-align: center;
+}
+
 /* Settings */
 .gear {
   position: fixed;
@@ -358,6 +402,10 @@ footer {
 .gear:hover {
   color: var(--count);
   background-color: color-mix(in srgb, var(--label) 20%, transparent);
+}
+
+.gear svg {
+  display: block;
 }
 
 .settings {
@@ -441,10 +489,36 @@ footer {
   transform: translateY(-1px);
 }
 
+/* The active preset carries a persistent ring; keyboard focus overrides it
+   (equal specificity, later rule wins) so focus is never masked. */
+.preset.is-active {
+  outline: 2px solid var(--count);
+  outline-offset: 2px;
+}
+
+.preset:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
 .preset i {
   width: 0.6rem;
   height: 0.6rem;
   border-radius: 50%;
+}
+
+.settings-hint {
+  margin: -0.35rem 0 0;
+  color: var(--label);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.contrast-note {
+  margin: -0.35rem 0 0;
+  color: var(--count);
+  font-size: 0.78rem;
+  line-height: 1.4;
 }
 
 .actions {

--- a/src/views.js
+++ b/src/views.js
@@ -1,7 +1,13 @@
 // Pure render functions for each screen. They build DOM and wire events to the
 // callbacks provided by the controller (tab.js).
 
-import { THEME_KEYS, cssDefault, PRESETS } from "./store.js";
+import {
+  THEME_KEYS,
+  cssDefault,
+  PRESETS,
+  contrast,
+  bestOnColor,
+} from "./store.js";
 import { listTimeZones, detectZone } from "./time.js";
 import { el } from "./dom.js";
 
@@ -11,6 +17,64 @@ const COLOR_LABELS = {
   count: "Counter",
   accent: "Accent",
 };
+
+// Guarded colours and their minimum WCAG contrast ratio against the background.
+const CONTRAST_MIN = { count: 4.5, label: 4.5, accent: 3 };
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+/** Build an SVG node. el() uses createElement (HTML only), so icons need this. */
+function svgEl(tag, attrs = {}, children = []) {
+  const node = document.createElementNS(SVG_NS, tag);
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value == null || value === false) continue;
+    node.setAttribute(key, value === true ? "" : String(value));
+  }
+  for (const child of [].concat(children)) {
+    if (child != null) node.appendChild(child);
+  }
+  return node;
+}
+
+/** A crisp, monochrome gear that inherits the button's currentColor. */
+function gearIcon() {
+  const line = { stroke: "currentColor", "stroke-width": "1.6" };
+  const teeth = Array.from({ length: 8 }, (_, i) => {
+    const a = (i * Math.PI) / 4;
+    return svgEl("line", {
+      x1: (12 + Math.cos(a) * 7).toFixed(2),
+      y1: (12 + Math.sin(a) * 7).toFixed(2),
+      x2: (12 + Math.cos(a) * 9.3).toFixed(2),
+      y2: (12 + Math.sin(a) * 9.3).toFixed(2),
+      "stroke-linecap": "round",
+      ...line,
+    });
+  });
+  return svgEl(
+    "svg",
+    {
+      viewBox: "0 0 24 24",
+      width: "22",
+      height: "22",
+      fill: "none",
+      "aria-hidden": "true",
+      focusable: "false",
+    },
+    [
+      svgEl("circle", { cx: "12", cy: "12", r: "6.4", ...line }),
+      svgEl("circle", { cx: "12", cy: "12", r: "2.4", ...line }),
+      ...teeth,
+    ],
+  );
+}
+
+/** Today as YYYY-MM-DD in local time, used to cap the birth-date field. */
+function todayISO() {
+  const now = new Date();
+  return new Date(now.getTime() - now.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 10);
+}
 
 /** Split a stored birth ("YYYY-MM-DD" or "YYYY-MM-DDTHH:mm") into [date, time]. */
 function splitBirth(value) {
@@ -25,6 +89,7 @@ export function renderSetup(app, { start }, current, savedZone) {
     id: "birth-date",
     "aria-label": "Date of birth",
     autocomplete: "bday",
+    max: todayISO(),
     required: true,
   });
   const timeEl = el("input", {
@@ -43,9 +108,26 @@ export function renderSetup(app, { start }, current, savedZone) {
   );
   zoneEl.value = selectedZone;
   const startBtn = el("button", { id: "start" }, "Start");
+  const errorEl = el("p", {
+    class: "field-error",
+    id: "birth-error",
+    role: "alert",
+    hidden: true,
+  });
   const form = el("form", {}, [
     el("h1", { class: "screen-title" }, "When were you born?"),
+    el(
+      "p",
+      { class: "screen-subtitle" },
+      "Your age, counting up live on every new tab.",
+    ),
     el("div", { class: "setup-row" }, [dateEl, timeEl]),
+    errorEl,
+    el(
+      "p",
+      { class: "hint setup-hint" },
+      "Time is optional — it sharpens the live count.",
+    ),
     el("div", { class: "setup-field" }, [
       el(
         "label",
@@ -73,12 +155,26 @@ export function renderSetup(app, { start }, current, savedZone) {
       dateEl.reportValidity();
       return;
     }
-    start(`${dateEl.value}T${timeEl.value || "00:00"}`, zoneEl.value);
+    const birth = `${dateEl.value}T${timeEl.value || "00:00"}`;
+    if (new Date(birth).getTime() > Date.now()) {
+      errorEl.textContent =
+        "That date is in the future — please check your birthday.";
+      errorEl.hidden = false;
+      dateEl.focus();
+      return;
+    }
+    errorEl.hidden = true;
+    start(birth, zoneEl.value);
   }
   form.addEventListener("submit", (event) => {
     event.preventDefault();
     submitBirth();
   });
+  [dateEl, timeEl].forEach((input) =>
+    input.addEventListener("input", () => {
+      errorEl.hidden = true;
+    }),
+  );
   [dateEl, timeEl, zoneEl].forEach((input) =>
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
@@ -95,7 +191,7 @@ export function renderCounter(app, { openSettings, onCycle }, { born }) {
   const gear = el(
     "button",
     { class: "gear", id: "gear", title: "Settings", "aria-label": "Settings" },
-    "\u2699",
+    gearIcon(),
   );
   const label = el("h1", { class: "age-label", id: "unit-label" }, "Age");
   const count = el("p", {
@@ -111,9 +207,15 @@ export function renderCounter(app, { openSettings, onCycle }, { born }) {
     id: "progress-fill",
   });
   const pct = el("span", { class: "pct", id: "pct" });
+  const unitHint = el(
+    "p",
+    { class: "unit-hint", "aria-hidden": "true" },
+    "Click to change units",
+  );
   const counter = el("div", { class: "counter" }, [
     label,
     count,
+    unitHint,
     el("div", { class: "meta" }, [
       el("div", { class: "progress", "aria-hidden": "true" }, progressFill),
       el("div", { class: "meta-row" }, [
@@ -138,17 +240,29 @@ export function renderCounter(app, { openSettings, onCycle }, { born }) {
 /** Settings screen: presets + colour pickers + life expectancy + resets. */
 export function renderSettings(app, actions, { theme, expectancy }) {
   const colorInputs = {};
-  const rows = THEME_KEYS.map((key) => {
-    const input = el("input", {
+  const notes = {};
+  const rows = THEME_KEYS.flatMap((key) => {
+    const attrs = {
       type: "color",
       id: `color-${key}`,
       value: (theme && theme[key]) || cssDefault(key),
-    });
+    };
+    if (CONTRAST_MIN[key]) attrs["aria-describedby"] = `warn-${key}`;
+    const input = el("input", attrs);
     colorInputs[key] = input;
-    return el("div", { class: "row" }, [
+    const row = el("div", { class: "row" }, [
       el("label", { for: `color-${key}` }, COLOR_LABELS[key]),
       input,
     ]);
+    if (!CONTRAST_MIN[key]) return [row];
+    const note = el("p", {
+      class: "contrast-note",
+      id: `warn-${key}`,
+      role: "status",
+      hidden: true,
+    });
+    notes[key] = note;
+    return [row, note];
   });
 
   const swatches = Object.entries(PRESETS).map(([name, preset]) =>
@@ -193,11 +307,16 @@ export function renderSettings(app, actions, { theme, expectancy }) {
     el("h1", { class: "screen-title" }, "Settings"),
     el("p", { class: "settings-label" }, "Presets"),
     el("div", { class: "presets" }, swatches),
+    el(
+      "p",
+      { class: "settings-hint" },
+      "A preset sets all four colors at once.",
+    ),
     el("p", { class: "settings-label" }, "Colors"),
     ...rows,
-    el("p", { class: "settings-label" }, "Memento mori"),
+    el("p", { class: "settings-label" }, "Life expectancy"),
     el("div", { class: "row" }, [
-      el("label", { for: "expectancy" }, "Life expectancy (years)"),
+      el("label", { for: "expectancy" }, "Years"),
       expectancyInput,
     ]),
     el("div", { class: "actions" }, [resetBirthdayBtn, resetColorsBtn]),
@@ -205,10 +324,47 @@ export function renderSettings(app, actions, { theme, expectancy }) {
   ]);
   app.replaceChildren(settings);
 
-  THEME_KEYS.forEach((key) => {
-    colorInputs[key].addEventListener("input", (event) =>
-      actions.setColor(key, event.target.value),
+  function activePreset() {
+    return (
+      Object.keys(PRESETS).find((name) =>
+        THEME_KEYS.every(
+          (key) =>
+            colorInputs[key].value.toLowerCase() ===
+            PRESETS[name][key].toLowerCase(),
+        ),
+      ) || null
     );
+  }
+  function refreshActive() {
+    const name = activePreset();
+    swatches.forEach((btn) => {
+      const on = btn.dataset.preset === name;
+      btn.classList.toggle("is-active", on);
+      btn.setAttribute("aria-pressed", String(on));
+    });
+  }
+  function refreshWarnings() {
+    const bg = colorInputs.bg.value;
+    THEME_KEYS.forEach((key) => {
+      const note = notes[key];
+      if (!note) return;
+      const ratio = contrast(colorInputs[key].value, bg);
+      if (ratio < CONTRAST_MIN[key]) {
+        note.textContent = `Low contrast (${ratio.toFixed(1)}:1). Aim for ${CONTRAST_MIN[key]}:1 on the background.`;
+        note.style.color = bestOnColor(bg);
+        note.hidden = false;
+      } else {
+        note.hidden = true;
+      }
+    });
+  }
+
+  THEME_KEYS.forEach((key) => {
+    colorInputs[key].addEventListener("input", (event) => {
+      actions.setColor(key, event.target.value);
+      refreshWarnings();
+      refreshActive();
+    });
   });
   swatches.forEach((btn) => {
     btn.addEventListener("click", () =>
@@ -221,4 +377,7 @@ export function renderSettings(app, actions, { theme, expectancy }) {
   resetBirthdayBtn.addEventListener("click", actions.resetBirthday);
   resetColorsBtn.addEventListener("click", actions.resetColors);
   doneBtn.addEventListener("click", actions.closeSettings);
+
+  refreshWarnings();
+  refreshActive();
 }

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -98,6 +98,39 @@ describe("renderSetup", () => {
     renderSetup(app, { start: vi.fn() }, "1990-05-15T00:00", "Asia/Tokyo");
     expect(app.querySelector("#birth-zone").value).toBe("Asia/Tokyo");
   });
+
+  it("caps the birth date at today", () => {
+    renderSetup(app, { start: vi.fn() }, null);
+    expect(app.querySelector("#birth-date").getAttribute("max")).toMatch(
+      /^\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  it("rejects a future birth date and surfaces an error", () => {
+    const start = vi.fn();
+    renderSetup(app, { start }, null);
+    app.querySelector("#birth-date").value = "2999-01-01";
+    app
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(start).not.toHaveBeenCalled();
+    const error = app.querySelector("#birth-error");
+    expect(error.hidden).toBe(false);
+    expect(error.textContent.length).toBeGreaterThan(0);
+  });
+
+  it("clears the future-date error once the field is edited", () => {
+    renderSetup(app, { start: vi.fn() }, null);
+    const dateEl = app.querySelector("#birth-date");
+    dateEl.value = "2999-01-01";
+    app
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(app.querySelector("#birth-error").hidden).toBe(false);
+    dateEl.value = "1990-01-01";
+    dateEl.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(app.querySelector("#birth-error").hidden).toBe(true);
+  });
 });
 
 describe("renderCounter", () => {
@@ -144,6 +177,18 @@ describe("renderCounter", () => {
     keydown(count, " ");
     keydown(count, "a");
     expect(onCycle).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders an SVG gear icon and a decorative unit hint", () => {
+    renderCounter(
+      app,
+      { openSettings: vi.fn(), onCycle: vi.fn() },
+      { born: "" },
+    );
+    expect(app.querySelector("#gear svg")).not.toBeNull();
+    const hint = app.querySelector(".unit-hint");
+    expect(hint).not.toBeNull();
+    expect(hint.getAttribute("aria-hidden")).toBe("true");
   });
 });
 
@@ -229,5 +274,36 @@ describe("renderSettings", () => {
     expect(a.resetBirthday).toHaveBeenCalledOnce();
     expect(a.resetColors).toHaveBeenCalledOnce();
     expect(a.closeSettings).toHaveBeenCalledOnce();
+  });
+
+  it("marks the preset matching the current colors as active", () => {
+    renderSettings(app, actions(), { theme: PRESETS.Void, expectancy: 80 });
+    const active = app.querySelector(".preset.is-active");
+    expect(active).not.toBeNull();
+    expect(active.dataset.preset).toBe("Void");
+    expect(active.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("warns when a guarded color fails contrast on the background", () => {
+    renderSettings(app, actions(), {
+      theme: {
+        bg: "#ffffff",
+        label: "#000000",
+        count: "#f2f2f2",
+        accent: "#000000",
+      },
+      expectancy: 80,
+    });
+    const note = app.querySelector("#warn-count");
+    expect(note).not.toBeNull();
+    expect(note.hidden).toBe(false);
+    expect(
+      app.querySelector("#color-count").getAttribute("aria-describedby"),
+    ).toBe("warn-count");
+  });
+
+  it("keeps contrast warnings hidden when colors pass", () => {
+    renderSettings(app, actions(), { theme: PRESETS.Void, expectancy: 80 });
+    expect(app.querySelector("#warn-count").hidden).toBe(true);
   });
 });


### PR DESCRIPTION
Design pass over `src/views.js` (with supporting `store.js`/`tab.css`), re-based on the current `el()`/no-innerHTML architecture and kept fully test-covered.

## Setup
- One-line subtitle explaining what the screen is for.
- Clarifies that time of birth is optional ("it sharpens the live count").
- Caps the birth date at today (`max`) and rejects future dates with an inline, `role="alert"` error that clears as soon as the field is edited.

## Counter
- Replaces the raw `⚙` glyph with a crisp, monochrome **SVG gear** (consistent across platforms, no emoji rendering).
- Adds a hover/focus-revealed "click to change units" hint so the click-to-cycle affordance is discoverable without competing with the number.

## Settings
- **Contrast guardrail:** warns (WCAG) when Counter/Label fall below 4.5:1 or Accent below 3:1 against the background. The note recolors itself (`bestOnColor`) so it stays legible even when the failing colour *is* the counter. Wired via `aria-describedby`.
- **Active-preset ring:** the preset matching the current colours is ringed and marked `aria-pressed`; keyboard focus overrides the ring (equal specificity, later rule wins) so focus is never masked.
- Adds a preset caption and clearer **"Life expectancy / Years"** labels.

## Under the hood
- Exports `contrast()` from `store.js`.
- 7 new unit tests covering the future-date guard, the SVG gear + unit hint, the contrast warnings, and the active-preset ring.

All changes use `el()` / `createElementNS` (no `innerHTML`). **108 tests pass**, Prettier clean, and the impeccable detector is clean apart from the pre-existing `.count .fraction` mask alpha-ramp (a mask gradient, not a palette colour).