### PR TITLE
Add years-left and days-left countdown counter modes

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -8,7 +8,15 @@ const KEY = "mortality";
 export const THEME_KEYS = ["bg", "label", "count", "accent"];
 
 // Counter display units, cycled by clicking the number.
-export const MODES = ["years", "calendar", "days", "weeks", "weeksLeft"];
+export const MODES = [
+  "years",
+  "calendar",
+  "days",
+  "weeks",
+  "yearsLeft",
+  "daysLeft",
+  "weeksLeft",
+];
 
 // Curated full-theme presets. Every set is contrast-checked (count & label ≥4.5:1
 // on bg, accent ≥3:1). Applying one writes all four THEME_KEYS at once.

--- a/src/tab.js
+++ b/src/tab.js
@@ -28,6 +28,8 @@ const LABELS = {
   calendar: "Calendar age",
   days: "Days lived",
   weeks: "Weeks lived",
+  yearsLeft: "Years left",
+  daysLeft: "Days left",
   weeksLeft: "Weeks left",
 };
 
@@ -126,7 +128,7 @@ function showCounter() {
       els.count.replaceChildren();
     } else {
       intEl = el("span", { class: "int" }, "0");
-      if (mode === "years") {
+      if (mode === "years" || mode === "yearsLeft") {
         fracEl = el("span", { class: "fraction", "aria-hidden": "true" }, "0");
         els.count.replaceChildren(
           intEl,
@@ -180,8 +182,9 @@ function showCounter() {
     const elapsed = now - bornMs;
     const years = elapsed / YEAR_MS;
 
-    if (mode === "years") {
-      const [whole, fraction] = years.toFixed(9).split(".");
+    if (mode === "years" || mode === "yearsLeft") {
+      const shown = mode === "years" ? years : Math.max(0, expectancy - years);
+      const [whole, fraction] = shown.toFixed(9).split(".");
       if (whole !== lastInt) {
         intEl.textContent = whole;
         lastInt = whole;
@@ -209,6 +212,11 @@ function showCounter() {
       let value;
       if (mode === "days") value = Math.floor(elapsed / DAY_MS);
       else if (mode === "weeks") value = Math.floor(elapsed / WEEK_MS);
+      else if (mode === "daysLeft")
+        value = Math.max(
+          0,
+          Math.round((expectancy * YEAR_MS - elapsed) / DAY_MS),
+        );
       else
         value = Math.max(
           0,

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -34,7 +34,15 @@ describe("constants", () => {
   });
 
   it("exposes the counter display modes", () => {
-    expect(MODES).toEqual(["years", "calendar", "days", "weeks", "weeksLeft"]);
+    expect(MODES).toEqual([
+      "years",
+      "calendar",
+      "days",
+      "weeks",
+      "yearsLeft",
+      "daysLeft",
+      "weeksLeft",
+    ]);
   });
 
   it("every preset defines a hex value for every theme key", () => {

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -161,6 +161,61 @@ describe("counter interactions", () => {
     expect(document.querySelector("#count .int").textContent).toBe(expected);
   });
 
+  it("renders the years-left countdown as a live fraction", async () => {
+    seed({ birth: "2000-01-01T00:00", mode: "yearsLeft", expectancy: 80 });
+    await boot();
+    expect(document.querySelector("#unit-label").textContent).toBe(
+      "Years left",
+    );
+
+    const whole = document.querySelector("#count .int").textContent;
+    const fraction = document.querySelector("#count .fraction").textContent;
+    const value = Number(`${whole}.${fraction}`);
+
+    // Counts down toward zero: never negative, never past the full expectancy,
+    // and strictly below it because the birth is in the past.
+    expect(value).toBeGreaterThanOrEqual(0);
+    expect(value).toBeLessThanOrEqual(80);
+    expect(value).toBeLessThan(80);
+
+    // Mirrors the implementation exactly: (expectancy - lived years) to 9 dp.
+    const bornMs = new Date("2000-01-01T00:00").getTime();
+    const [expWhole, expFraction] = Math.max(
+      0,
+      80 - (Date.now() - bornMs) / YEAR_MS,
+    )
+      .toFixed(9)
+      .split(".");
+    expect(whole).toBe(expWhole);
+    expect(fraction).toBe(expFraction);
+
+    // Advancing the clock shrinks the remaining time.
+    vi.setSystemTime(new Date("2020-01-02T00:00:00"));
+    await vi.advanceTimersByTimeAsync(150);
+    const later = Number(
+      `${document.querySelector("#count .int").textContent}.${
+        document.querySelector("#count .fraction").textContent
+      }`,
+    );
+    expect(later).toBeLessThan(value);
+  });
+
+  it("renders the days-left countdown from life expectancy", async () => {
+    seed({ birth: "2000-01-01T00:00", mode: "daysLeft", expectancy: 80 });
+    await boot();
+    expect(document.querySelector("#unit-label").textContent).toBe("Days left");
+
+    const bornMs = new Date("2000-01-01T00:00").getTime();
+    const elapsed = Date.now() - bornMs;
+    const expected = Math.max(0, Math.round((80 * YEAR_MS - elapsed) / DAY_MS));
+    expect(document.querySelector("#count .int").textContent).toBe(
+      expected.toLocaleString(),
+    );
+    // A normal past birth leaves a positive whole number of days remaining.
+    expect(expected).toBeGreaterThan(0);
+    expect(Number.isInteger(expected)).toBe(true);
+  });
+
   it("renders the calendar-age breakdown as number + unit spans", async () => {
     // System clock is 2020-01-01 and the birth is 2000-01-01 (same wall-clock
     // date twenty years apart), so the breakdown is exactly 20yr 0mo 0d.


### PR DESCRIPTION
Adds two countdown display modes so the time-left family mirrors the lived-side modes, alongside the existing `weeksLeft`:

- **`yearsLeft`** — fractional years remaining until life expectancy, rendered exactly like `years` (integer + 9-digit fraction) and ticking live *downward*. Computed as `Math.max(0, expectancy - years)`. Label: "Years left".
- **`daysLeft`** — whole days remaining until expectancy, rendered like `days`/`weeks` (single localized integer). Computed as `Math.max(0, Math.round((expectancy * YEAR_MS - elapsed) / DAY_MS))`, mirroring the existing `weeksLeft` rounding.

The click-cycle order groups all lived modes, then all left modes: `years, calendar, days, weeks, yearsLeft, daysLeft, weeksLeft`.

The life-progress meter and its "% of N yrs lived" caption are unchanged for every mode — only the big number and its label change. No new dependencies, no CSS, and no zone-math changes.

**Tests:** `store.test.js` MODES assertion updated to the new 7-element order; `tab.integration.test.js` gains coverage for the `yearsLeft` (counts down, strictly below expectancy, live decrement) and `daysLeft` (exact rounded integer) modes. Full suite green.