### PR TITLE
Add a Life in weeks grid view

### DIFF
--- a/src/tab.css
+++ b/src/tab.css
@@ -408,6 +408,13 @@ footer {
   display: block;
 }
 
+/* Second corner button (life-in-weeks entry, weeks-view back): reuses every
+   .gear rule, just mirrored to the top-left. */
+.gear.corner-left {
+  right: auto;
+  left: 0.75rem;
+}
+
 .settings {
   display: flex;
   flex-direction: column;
@@ -545,6 +552,91 @@ footer {
   filter: none;
   color: var(--count);
   border-color: var(--count);
+}
+
+/* Life in weeks: a full-screen calendar where each row is a year and each cell a
+   week. Taller than the viewport, so the screen scrolls from the top instead of
+   the base centred layout (which would clip the grid). */
+body.screen-weeks {
+  justify-content: flex-start;
+  height: auto;
+  min-height: 100%;
+  overflow-y: auto;
+  padding: 2.5rem 0;
+}
+
+.weeks-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 1.25rem;
+}
+
+.weeks-head {
+  text-align: center;
+}
+
+.weeks-head .age-label {
+  text-align: center;
+}
+
+.weeks-grid {
+  display: grid;
+  grid-template-columns: repeat(52, 1fr);
+  gap: 2px;
+  width: min(92vw, 620px);
+}
+
+.weeks-grid i {
+  aspect-ratio: 1/1;
+  border-radius: 1px;
+}
+
+.weeks-grid i.lived {
+  background: color-mix(in srgb, var(--count) 62%, var(--bg));
+}
+
+.weeks-grid i.now {
+  background: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
+.weeks-grid i.future {
+  background: color-mix(in srgb, var(--label) 20%, transparent);
+}
+
+.weeks-legend {
+  display: flex;
+  gap: 1.2rem;
+  color: var(--label);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.weeks-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.weeks-legend i {
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 1px;
+}
+
+.weeks-legend i.lived {
+  background: color-mix(in srgb, var(--count) 62%, var(--bg));
+}
+
+.weeks-legend i.now {
+  background: var(--accent);
+}
+
+.weeks-legend i.future {
+  background: color-mix(in srgb, var(--label) 20%, transparent);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/tab.js
+++ b/src/tab.js
@@ -9,7 +9,12 @@ import {
   MODES,
   PRESETS,
 } from "./store.js";
-import { renderSetup, renderCounter, renderSettings } from "./views.js";
+import {
+  renderSetup,
+  renderCounter,
+  renderSettings,
+  renderWeeks,
+} from "./views.js";
 import {
   birthInstantMs,
   calendarAge,
@@ -81,6 +86,14 @@ export function formatBorn(birth) {
   }
 }
 
+// Split a life into week cells: `total` = expectancy years × 52, `lived` = whole
+// weeks elapsed (clamped to [0, total]). Pure so the grid maths is unit-testable.
+export function lifeWeeks(elapsedMs, expectancy) {
+  const total = clampExpectancy(expectancy) * 52;
+  const lived = Math.max(0, Math.floor(elapsedMs / WEEK_MS));
+  return { lived: Math.min(lived, total), total };
+}
+
 function showSetup() {
   stopTimer();
   setScreen("setup");
@@ -108,7 +121,7 @@ function showCounter() {
 
   const els = renderCounter(
     app,
-    { openSettings: showSettings, onCycle: cycle },
+    { openSettings: showSettings, onCycle: cycle, openWeeks: showWeeks },
     { born: formatBorn(state.birth) },
   );
 
@@ -246,6 +259,26 @@ function showCounter() {
 
   layout();
   tick();
+}
+
+// Full-screen life calendar: one row per year, one cell per week. Static per
+// open (no ticker) — stopTimer() cancels the counter loop before we switch.
+function showWeeks() {
+  stopTimer();
+  setScreen("weeks");
+  const zone = isValidZone(state.birthZone) ? state.birthZone : detectZone();
+  const bornMs = birthInstantMs(state.birth, zone);
+  const { lived, total } = lifeWeeks(Date.now() - bornMs, state.expectancy);
+  renderWeeks(
+    app,
+    { back: showCounter, openSettings: showSettings },
+    {
+      born: formatBorn(state.birth),
+      lived,
+      total,
+      expectancy: clampExpectancy(state.expectancy),
+    },
+  );
 }
 
 function showSettings() {

--- a/src/views.js
+++ b/src/views.js
@@ -187,11 +187,25 @@ export function renderSetup(app, { start }, current, savedZone) {
 }
 
 /** Live age counter. Returns the elements the ticker updates. */
-export function renderCounter(app, { openSettings, onCycle }, { born }) {
+export function renderCounter(
+  app,
+  { openSettings, onCycle, openWeeks },
+  { born },
+) {
   const gear = el(
     "button",
     { class: "gear", id: "gear", title: "Settings", "aria-label": "Settings" },
     gearIcon(),
+  );
+  const weeksBtn = el(
+    "button",
+    {
+      class: "gear corner-left",
+      id: "weeks-btn",
+      title: "Life in weeks",
+      "aria-label": "Life in weeks",
+    },
+    "\u25a6",
   );
   const label = el("h1", { class: "age-label", id: "unit-label" }, "Age");
   const count = el("p", {
@@ -224,9 +238,10 @@ export function renderCounter(app, { openSettings, onCycle }, { born }) {
       ]),
     ]),
   ]);
-  app.replaceChildren(gear, counter);
+  app.replaceChildren(weeksBtn, gear, counter);
 
   gear.addEventListener("click", openSettings);
+  weeksBtn.addEventListener("click", openWeeks);
   count.addEventListener("click", onCycle);
   count.addEventListener("keydown", (event) => {
     if (event.key === "Enter" || event.key === " ") {
@@ -380,4 +395,63 @@ export function renderSettings(app, actions, { theme, expectancy }) {
 
   refreshWarnings();
   refreshActive();
+}
+
+/**
+ * Life-in-weeks grid: every row is a year of the expectancy, every cell a week —
+ * lived weeks filled, the current week accented, the rest dim. Static per open;
+ * the grid is decorative (aria-hidden) and the subtitle carries the real counts.
+ */
+export function renderWeeks(
+  app,
+  { back, openSettings },
+  { born, lived, total, expectancy },
+) {
+  const backBtn = el(
+    "button",
+    {
+      class: "gear corner-left",
+      id: "weeks-back",
+      title: "Back",
+      "aria-label": "Back",
+    },
+    "\u2190",
+  );
+  const gear = el(
+    "button",
+    { class: "gear", id: "gear", title: "Settings", "aria-label": "Settings" },
+    gearIcon(),
+  );
+
+  const grid = el("div", { class: "weeks-grid", "aria-hidden": "true" });
+  const cells = document.createDocumentFragment();
+  for (let i = 0; i < total; i++) {
+    const cls = i < lived ? "lived" : i === lived ? "now" : "future";
+    cells.append(el("i", { class: cls }));
+  }
+  grid.append(cells);
+
+  const wrap = el("div", { class: "weeks-wrap" }, [
+    el("div", { class: "weeks-head" }, [
+      el("h1", { class: "age-label" }, "Life in weeks"),
+      el(
+        "p",
+        { class: "hint" },
+        `${lived.toLocaleString()} weeks lived \u00b7 ${(
+          total - lived
+        ).toLocaleString()} ahead \u00b7 ${expectancy} yrs`,
+      ),
+    ]),
+    grid,
+    el("div", { class: "weeks-legend" }, [
+      el("span", {}, [el("i", { class: "lived" }), " Lived"]),
+      el("span", {}, [el("i", { class: "now" }), " This week"]),
+      el("span", {}, [el("i", { class: "future" }), " Ahead"]),
+    ]),
+  ]);
+
+  app.replaceChildren(backBtn, gear, wrap);
+
+  backBtn.addEventListener("click", back);
+  gear.addEventListener("click", openSettings);
 }

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -331,3 +331,28 @@ describe("reduced motion", () => {
     expect(animateSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("life in weeks", () => {
+  it("opens the weeks grid from the counter and returns via back", async () => {
+    seed({ birth: "2000-01-01T00:00", expectancy: 80 });
+    await boot();
+    expect(document.body.className).toBe("screen-counter");
+
+    document.querySelector('[aria-label="Life in weeks"]').click();
+    expect(document.body.className).toBe("screen-weeks");
+
+    const WEEK_MS = 7 * DAY_MS;
+    const total = 80 * 52;
+    const bornMs = new Date("2000-01-01T00:00").getTime();
+    const lived = Math.floor((Date.now() - bornMs) / WEEK_MS);
+
+    const grid = document.querySelector(".weeks-grid");
+    expect(grid.querySelectorAll("i").length).toBe(total);
+    expect(grid.querySelectorAll("i.lived").length).toBe(lived);
+    expect(grid.querySelectorAll("i.now").length).toBe(1);
+    expect(grid.querySelectorAll("i.future").length).toBe(total - lived - 1);
+
+    document.querySelector('[aria-label="Back"]').click();
+    expect(document.body.className).toBe("screen-counter");
+  });
+});

--- a/test/tab.test.js
+++ b/test/tab.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { clampExpectancy, formatBorn } from "../src/tab.js";
+import { clampExpectancy, formatBorn, lifeWeeks } from "../src/tab.js";
 
 describe("clampExpectancy", () => {
   it("keeps in-range integers", () => {
@@ -41,5 +41,32 @@ describe("formatBorn", () => {
   it("returns an empty string for an unparseable value", () => {
     expect(formatBorn("not-a-date")).toBe("");
     expect(formatBorn("")).toBe("");
+  });
+});
+
+const WEEK_MS = 7 * 86400000;
+
+describe("lifeWeeks", () => {
+  it("has zero lived weeks and expectancy*52 total at birth", () => {
+    expect(lifeWeeks(0, 80)).toEqual({ lived: 0, total: 4160 });
+  });
+
+  it("counts whole weeks elapsed", () => {
+    expect(lifeWeeks(WEEK_MS * 10, 80).lived).toBe(10);
+  });
+
+  it("clamps negative elapsed time to zero lived weeks", () => {
+    expect(lifeWeeks(-WEEK_MS * 5, 80).lived).toBe(0);
+  });
+
+  it("never lets lived exceed the total number of cells", () => {
+    const { lived, total } = lifeWeeks(Number.MAX_SAFE_INTEGER, 80);
+    expect(total).toBe(4160);
+    expect(lived).toBe(total);
+  });
+
+  it("scales the total with the clamped expectancy", () => {
+    expect(lifeWeeks(0, 200).total).toBe(150 * 52);
+    expect(lifeWeeks(0, "abc").total).toBe(80 * 52);
   });
 });


### PR DESCRIPTION
New full-screen weeks-grid view: each row is a year of the configured life expectancy and each of the 52 cells in a row is a week — lived weeks filled, the current week accented, future weeks dim. Reachable via a top-left grid button (▦) on the counter, with a back button; the screen is static per open (no ticker).

- Pure, exported `lifeWeeks()` helper (unit-tested) computes lived/total week counts.
- Integration test covers the counter entry point, the rendered cell counts/classes (one `.now`, correct `.lived`/`.future`), and back navigation to the counter.
- No new dependencies; built with `el()` (no `innerHTML`) and theme-token CSS. The gear reuses the shared `gearIcon()`.
- The weeks-screen body scrolls from the top so the grid is never clipped.

Touched: `src/tab.js`, `src/views.js`, `src/tab.css`, `test/tab.test.js`, `test/tab.integration.test.js`.