### PR TITLE
Add Settings: numeral typeface, reflection line, birth-zone control, export/import

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,10 @@ const KEY = "mortality";
 // Colors the user can customise. Each maps to a CSS custom property (--<key>).
 export const THEME_KEYS = ["bg", "label", "count", "accent"];
 
+// Numeral typefaces for the big count, chosen in Settings. Each maps to a
+// --num-font value applied by applyTypeface (see below); "system" clears it.
+export const TYPEFACES = ["system", "grotesk", "mono"];
+
 // Counter display units, cycled by clicking the number.
 export const MODES = [
   "years",
@@ -60,6 +64,8 @@ const DEFAULTS = {
   theme: null,
   expectancy: 80,
   mode: "years",
+  typeface: "system",
+  reflection: false,
 };
 
 // Extension storage.local persists across the privacy/history clearing that can
@@ -140,7 +146,7 @@ function backfillZone(state) {
  * that predate timezone support get their birthZone backfilled with the
  * detected zone (see backfillZone) so the birth instant is anchored going
  * forward without changing the age shown today.
- * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, mode: string }>}
+ * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, mode: string, typeface: string, reflection: boolean }>}
  */
 export async function load() {
   let stored;
@@ -218,4 +224,27 @@ export function applyTheme(theme) {
     else root.removeProperty(`--${key}`);
   });
   root.setProperty("--on-accent", bestOnColor(cssDefault("accent")));
+}
+
+/**
+ * Set the numeral typeface for the big count as an inline custom property, so it
+ * survives setScreen() rewriting body.className (a body class would not). "mono"
+ * and "grotesk" pick a font stack; anything else clears the override and the
+ * number inherits the page font (see the `.count` rule's var(--num-font)).
+ */
+export function applyTypeface(typeface) {
+  const root = document.documentElement.style;
+  if (typeface === "mono") {
+    root.setProperty(
+      "--num-font",
+      'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+    );
+  } else if (typeface === "grotesk") {
+    root.setProperty(
+      "--num-font",
+      '"Avenir Next", "Helvetica Neue", Arial, sans-serif',
+    );
+  } else {
+    root.removeProperty("--num-font");
+  }
 }

--- a/src/tab.css
+++ b/src/tab.css
@@ -136,6 +136,7 @@ body.screen-counter #app {
   font-size: clamp(2.75rem, 13vw, 6rem);
   line-height: 1;
   font-weight: 600;
+  font-family: var(--num-font, inherit);
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum" 1;
   cursor: pointer;
@@ -255,6 +256,16 @@ body.screen-counter #app {
 .meta-row .pct {
   text-align: right;
   white-space: nowrap;
+}
+
+/* Optional editorial line under the meter (Settings → Display → Reflection). */
+.reflection {
+  margin-top: 1.1rem;
+  color: color-mix(in srgb, var(--label) 82%, transparent);
+  font-size: 0.82rem;
+  font-style: italic;
+  letter-spacing: 0.01em;
+  max-width: 24rem;
 }
 
 label {
@@ -552,6 +563,71 @@ footer {
   filter: none;
   color: var(--count);
   border-color: var(--count);
+}
+
+/* Display section: segmented numeral-typeface control + a reflection toggle. */
+.segment {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 0.4rem;
+  overflow: hidden;
+}
+
+.segment button {
+  font-size: 0.9rem;
+  padding: 0.3rem 0.7rem;
+  color: var(--label);
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
+.segment button[aria-pressed="true"] {
+  color: var(--on-accent);
+  background: var(--accent);
+}
+
+.segment button.mono {
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.segment button.grotesk {
+  font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+}
+
+.switch {
+  position: relative;
+  width: 2.6rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--label) 18%, transparent);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.15s ease;
+}
+
+.switch[aria-checked="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.switch::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 0.18rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  border-radius: 50%;
+  background: #fff;
+  transform: translateY(-50%);
+  transition: left 0.15s ease;
+}
+
+.switch[aria-checked="true"]::after {
+  left: calc(100% - 1.23rem);
 }
 
 /* Life in weeks: a full-screen calendar where each row is a year and each cell a

--- a/src/tab.js
+++ b/src/tab.js
@@ -4,9 +4,11 @@ import {
   load,
   save,
   applyTheme,
+  applyTypeface,
   cssDefault,
   THEME_KEYS,
   MODES,
+  TYPEFACES,
   PRESETS,
 } from "./store.js";
 import {
@@ -94,6 +96,34 @@ export function lifeWeeks(elapsedMs, expectancy) {
   return { lived: Math.min(lived, total), total };
 }
 
+// The optional editorial line under the counter: whole years lived vs. years
+// remaining against the expectancy (never negative). Number-based and pure so it
+// is deterministic and unit-testable; recomputed once per counter show.
+export function reflectionLine(bornMs, nowMs, expectancy) {
+  const lived = Math.max(0, Math.floor((nowMs - bornMs) / YEAR_MS));
+  const ahead = Math.max(0, expectancy - lived);
+  return `${lived} years behind you \u00b7 ${ahead} ahead, if the tables hold.`;
+}
+
+// Fold an imported settings blob onto the current state, copying ONLY known keys
+// and sanitising each so a hand-edited or foreign file can't inject junk. Unknown
+// keys are ignored; a key the import omits keeps its current value. Pure.
+export function mergeImported(current, imported) {
+  const src = imported && typeof imported === "object" ? imported : {};
+  const known = {};
+  if ("version" in src) known.version = src.version;
+  if ("birth" in src)
+    known.birth = typeof src.birth === "string" ? src.birth : null;
+  if ("birthZone" in src) known.birthZone = src.birthZone;
+  if ("theme" in src) known.theme = src.theme;
+  if ("expectancy" in src) known.expectancy = clampExpectancy(src.expectancy);
+  if ("mode" in src && MODES.includes(src.mode)) known.mode = src.mode;
+  if ("typeface" in src)
+    known.typeface = TYPEFACES.includes(src.typeface) ? src.typeface : "system";
+  if ("reflection" in src) known.reflection = Boolean(src.reflection);
+  return { ...current, ...known };
+}
+
 function showSetup() {
   stopTimer();
   setScreen("setup");
@@ -119,10 +149,16 @@ function showCounter() {
   const expectancy = clampExpectancy(state.expectancy);
   let mode = MODES.includes(state.mode) ? state.mode : "years";
 
+  // The reflection line changes at most once a year, so compute it once on show
+  // and hand it to the renderer — the ticker never has to touch it.
+  const reflection = state.reflection
+    ? reflectionLine(bornMs, Date.now(), expectancy)
+    : null;
+
   const els = renderCounter(
     app,
     { openSettings: showSettings, onCycle: cycle, openWeeks: showWeeks },
-    { born: formatBorn(state.birth) },
+    { born: formatBorn(state.birth), reflection },
   );
 
   let intEl = null;
@@ -316,11 +352,72 @@ function showSettings() {
       resetBirthday() {
         showSetup();
       },
+      setTypeface(value) {
+        state.typeface = value;
+        save(state);
+        applyTypeface(value);
+        showSettings();
+      },
+      toggleReflection() {
+        state.reflection = !state.reflection;
+        save(state);
+        showSettings();
+      },
+      setZone(value) {
+        state.birthZone = value;
+        save(state);
+      },
+      exportData() {
+        const blob = new Blob([JSON.stringify(state, null, 2)], {
+          type: "application/json",
+        });
+        const a = el("a", {
+          href: URL.createObjectURL(blob),
+          download: "mortality-settings.json",
+        });
+        document.body.append(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(a.href);
+      },
+      importData() {
+        const input = el("input", {
+          type: "file",
+          accept: "application/json",
+          hidden: true,
+        });
+        input.addEventListener("change", async () => {
+          const file = input.files && input.files[0];
+          input.remove();
+          if (!file) return;
+          let parsed;
+          try {
+            parsed = JSON.parse(await file.text());
+          } catch (err) {
+            console.warn("Mortality: could not read imported settings", err);
+            return;
+          }
+          state = mergeImported(state, parsed);
+          save(state);
+          applyTheme(state.theme);
+          applyTypeface(state.typeface);
+          if (state.birth) showCounter();
+          else showSetup();
+        });
+        document.body.append(input);
+        input.click();
+      },
       closeSettings() {
         showCounter();
       },
     },
-    { theme: state.theme, expectancy: clampExpectancy(state.expectancy) },
+    {
+      theme: state.theme,
+      expectancy: clampExpectancy(state.expectancy),
+      typeface: state.typeface,
+      reflection: state.reflection,
+      birthZone: state.birthZone,
+    },
   );
 }
 
@@ -445,6 +542,7 @@ function updateAmbient() {
 async function init() {
   state = await load();
   applyTheme(state.theme);
+  applyTypeface(state.typeface);
   setupAmbient();
   if (state.birth) showCounter();
   else showSetup();

--- a/src/views.js
+++ b/src/views.js
@@ -18,6 +18,14 @@ const COLOR_LABELS = {
   accent: "Accent",
 };
 
+// Numeral typeface choices for the Display segmented control:
+// [value, button label, optional class that previews the font on the button].
+const TYPEFACE_OPTIONS = [
+  ["system", "System", null],
+  ["grotesk", "Grotesk", "grotesk"],
+  ["mono", "Mono", "mono"],
+];
+
 // Guarded colours and their minimum WCAG contrast ratio against the background.
 const CONTRAST_MIN = { count: 4.5, label: 4.5, accent: 3 };
 
@@ -190,7 +198,7 @@ export function renderSetup(app, { start }, current, savedZone) {
 export function renderCounter(
   app,
   { openSettings, onCycle, openWeeks },
-  { born },
+  { born, reflection },
 ) {
   const gear = el(
     "button",
@@ -238,6 +246,10 @@ export function renderCounter(
       ]),
     ]),
   ]);
+  // An optional editorial line under the meter, on only when the user asks for it.
+  if (reflection) {
+    counter.append(el("p", { class: "reflection" }, reflection));
+  }
   app.replaceChildren(weeksBtn, gear, counter);
 
   gear.addEventListener("click", openSettings);
@@ -253,7 +265,11 @@ export function renderCounter(
 }
 
 /** Settings screen: presets + colour pickers + life expectancy + resets. */
-export function renderSettings(app, actions, { theme, expectancy }) {
+export function renderSettings(
+  app,
+  actions,
+  { theme, expectancy, typeface, reflection, birthZone },
+) {
   const colorInputs = {};
   const notes = {};
   const rows = THEME_KEYS.flatMap((key) => {
@@ -306,6 +322,66 @@ export function renderSettings(app, actions, { theme, expectancy }) {
     step: "1",
     value: expectancy,
   });
+
+  // Display: numeral typeface (segmented control) + reflection-line toggle.
+  const numeralsLabel = el("label", { id: "numerals-label" }, "Numerals");
+  const typefaceButtons = TYPEFACE_OPTIONS.map(([value, text, cls]) => {
+    const btn = el(
+      "button",
+      {
+        type: "button",
+        class: cls,
+        "data-typeface": value,
+        "aria-pressed": String(typeface === value),
+      },
+      text,
+    );
+    btn.addEventListener("click", () => actions.setTypeface(value));
+    return btn;
+  });
+  const typefaceSegment = el(
+    "div",
+    { class: "segment", role: "group", "aria-labelledby": "numerals-label" },
+    typefaceButtons,
+  );
+  const reflectionSwitch = el("button", {
+    type: "button",
+    class: "switch",
+    id: "reflection-switch",
+    role: "switch",
+    "aria-checked": String(Boolean(reflection)),
+  });
+  reflectionSwitch.addEventListener("click", actions.toggleReflection);
+
+  // Time zone: re-anchor the birth instant to a different zone after setup.
+  const detected = detectZone();
+  const selectedZone = birthZone || detected;
+  const zoneSelect = el(
+    "select",
+    { id: "settings-zone" },
+    listTimeZones(selectedZone, detected).map((zone) =>
+      el("option", { value: zone }, zone),
+    ),
+  );
+  zoneSelect.value = selectedZone;
+  zoneSelect.addEventListener("change", (event) =>
+    actions.setZone(event.target.value),
+  );
+
+  // Data: export the whole state as JSON, or import a previously saved file.
+  const exportBtn = el(
+    "button",
+    { type: "button", id: "export-data", class: "btn-secondary" },
+    "Export\u2026",
+  );
+  const importBtn = el(
+    "button",
+    { type: "button", id: "import-data", class: "btn-secondary" },
+    "Import\u2026",
+  );
+  exportBtn.addEventListener("click", actions.exportData);
+  importBtn.addEventListener("click", actions.importData);
+
   const resetBirthdayBtn = el(
     "button",
     { id: "reset-birthday", class: "btn-secondary" },
@@ -329,11 +405,33 @@ export function renderSettings(app, actions, { theme, expectancy }) {
     ),
     el("p", { class: "settings-label" }, "Colors"),
     ...rows,
+    el("p", { class: "settings-label" }, "Display"),
+    el("div", { class: "row" }, [numeralsLabel, typefaceSegment]),
+    el("div", { class: "row" }, [
+      el(
+        "label",
+        { for: "reflection-switch" },
+        "Reflection line under the counter",
+      ),
+      reflectionSwitch,
+    ]),
     el("p", { class: "settings-label" }, "Life expectancy"),
     el("div", { class: "row" }, [
       el("label", { for: "expectancy" }, "Years"),
       expectancyInput,
     ]),
+    el("p", { class: "settings-label" }, "Time zone"),
+    el("div", { class: "setup-field" }, [
+      el("label", { class: "setup-label", for: "settings-zone" }, "Born in"),
+      zoneSelect,
+      el(
+        "p",
+        { class: "hint" },
+        "Anchors your birthday to a fixed instant, so your age stays exact when you travel.",
+      ),
+    ]),
+    el("p", { class: "settings-label" }, "Data"),
+    el("div", { class: "actions" }, [exportBtn, importBtn]),
     el("div", { class: "actions" }, [resetBirthdayBtn, resetColorsBtn]),
     el("div", { class: "actions" }, [doneBtn]),
   ]);

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -3,11 +3,13 @@ import {
   THEME_KEYS,
   MODES,
   PRESETS,
+  TYPEFACES,
   load,
   save,
   cssDefault,
   bestOnColor,
   applyTheme,
+  applyTypeface,
 } from "../src/store.js";
 
 // Independent WCAG contrast implementation, used to verify the PRESETS meet the
@@ -43,6 +45,10 @@ describe("constants", () => {
       "daysLeft",
       "weeksLeft",
     ]);
+  });
+
+  it("exposes the selectable numeral typefaces", () => {
+    expect(TYPEFACES).toEqual(["system", "grotesk", "mono"]);
   });
 
   it("every preset defines a hex value for every theme key", () => {
@@ -133,6 +139,38 @@ describe("applyTheme", () => {
   });
 });
 
+describe("applyTypeface", () => {
+  it("sets a monospace stack for the mono typeface", () => {
+    applyTypeface("mono");
+    expect(
+      document.documentElement.style.getPropertyValue("--num-font"),
+    ).toContain("ui-monospace");
+  });
+
+  it("sets a grotesk stack for the grotesk typeface", () => {
+    applyTypeface("grotesk");
+    expect(
+      document.documentElement.style.getPropertyValue("--num-font"),
+    ).toContain("Avenir Next");
+  });
+
+  it("removes the property for the system typeface", () => {
+    applyTypeface("mono");
+    applyTypeface("system");
+    expect(document.documentElement.style.getPropertyValue("--num-font")).toBe(
+      "",
+    );
+  });
+
+  it("removes the property for any unknown typeface", () => {
+    applyTypeface("grotesk");
+    applyTypeface("wingdings");
+    expect(document.documentElement.style.getPropertyValue("--num-font")).toBe(
+      "",
+    );
+  });
+});
+
 describe("save / load with the localStorage fallback", () => {
   it("returns defaults when nothing is stored", async () => {
     await expect(load()).resolves.toEqual({
@@ -142,6 +180,8 @@ describe("save / load with the localStorage fallback", () => {
       theme: null,
       expectancy: 80,
       mode: "years",
+      typeface: "system",
+      reflection: false,
     });
   });
 
@@ -153,6 +193,8 @@ describe("save / load with the localStorage fallback", () => {
       theme: { bg: "#111111", label: "#aaa", count: "#fff", accent: "#f00" },
       expectancy: 70,
       mode: "days",
+      typeface: "mono",
+      reflection: true,
     };
     await save(state);
     await expect(load()).resolves.toEqual(state);
@@ -167,6 +209,8 @@ describe("save / load with the localStorage fallback", () => {
       theme: null,
       expectancy: 80,
       mode: "years",
+      typeface: "system",
+      reflection: false,
     });
   });
 
@@ -208,6 +252,8 @@ describe("save / load with the localStorage fallback", () => {
       theme: null,
       expectancy: 80,
       mode: "years",
+      typeface: "system",
+      reflection: false,
     });
   });
 
@@ -229,6 +275,8 @@ describe("save / load with the localStorage fallback", () => {
       theme: null,
       expectancy: 80,
       mode: "years",
+      typeface: "system",
+      reflection: false,
     });
   });
 });
@@ -279,6 +327,8 @@ describe("save / load against extension storage", () => {
       theme: null,
       expectancy: 95,
       mode: "years",
+      typeface: "system",
+      reflection: false,
     });
   });
 
@@ -315,6 +365,8 @@ describe("save / load against extension storage", () => {
       theme: null,
       expectancy: 80,
       mode: "years",
+      typeface: "system",
+      reflection: false,
     });
   });
 });

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -310,6 +310,67 @@ describe("settings routing and edits", () => {
   });
 });
 
+describe("settings: display, reflection, and zone", () => {
+  beforeEach(() => {
+    seed({ birth: "2000-01-01T00:00" });
+  });
+
+  it("activates a numeral typeface, persisting it and setting --num-font", async () => {
+    await boot();
+    document.querySelector("#gear").click();
+    document.querySelector('[data-typeface="mono"]').click();
+
+    expect(stored().typeface).toBe("mono");
+    expect(
+      document.documentElement.style.getPropertyValue("--num-font"),
+    ).toContain("ui-monospace");
+
+    // The re-rendered segment marks the active choice via aria-pressed.
+    expect(
+      document
+        .querySelector('[data-typeface="mono"]')
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      document
+        .querySelector('[data-typeface="system"]')
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("toggles the reflection line on and renders it on the counter", async () => {
+    await boot();
+    document.querySelector("#gear").click();
+
+    const sw = document.querySelector("#reflection-switch");
+    expect(sw.getAttribute("aria-checked")).toBe("false");
+    sw.click();
+
+    expect(stored().reflection).toBe(true);
+    expect(
+      document.querySelector("#reflection-switch").getAttribute("aria-checked"),
+    ).toBe("true");
+
+    document.querySelector("#done").click();
+    expect(document.body.className).toBe("screen-counter");
+    expect(document.querySelector(".reflection")).not.toBeNull();
+  });
+
+  it("leaves the counter free of a reflection line when the toggle is off", async () => {
+    await boot();
+    expect(document.querySelector(".reflection")).toBeNull();
+  });
+
+  it("persists a changed birth time zone from settings", async () => {
+    await boot();
+    document.querySelector("#gear").click();
+    const zone = document.querySelector("#settings-zone");
+    zone.value = "Asia/Tokyo";
+    zone.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(stored().birthZone).toBe("Asia/Tokyo");
+  });
+});
+
 describe("reduced motion", () => {
   it("skips the count fade animation when the user prefers reduced motion", async () => {
     window.matchMedia = vi.fn((query) => ({

--- a/test/tab.test.js
+++ b/test/tab.test.js
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { clampExpectancy, formatBorn, lifeWeeks } from "../src/tab.js";
+import {
+  clampExpectancy,
+  formatBorn,
+  lifeWeeks,
+  reflectionLine,
+  mergeImported,
+} from "../src/tab.js";
+
+const YEAR_MS = 31556900000;
 
 describe("clampExpectancy", () => {
   it("keeps in-range integers", () => {
@@ -68,5 +76,110 @@ describe("lifeWeeks", () => {
   it("scales the total with the clamped expectancy", () => {
     expect(lifeWeeks(0, 200).total).toBe(150 * 52);
     expect(lifeWeeks(0, "abc").total).toBe(80 * 52);
+  });
+});
+
+describe("reflectionLine", () => {
+  it("reports whole years behind and ahead against the expectancy", () => {
+    const born = 0;
+    const now = 30 * YEAR_MS;
+    expect(reflectionLine(born, now, 80)).toBe(
+      "30 years behind you \u00b7 50 ahead, if the tables hold.",
+    );
+  });
+
+  it("floors the years lived rather than rounding", () => {
+    const now = 29.9 * YEAR_MS;
+    expect(reflectionLine(0, now, 80)).toBe(
+      "29 years behind you \u00b7 51 ahead, if the tables hold.",
+    );
+  });
+
+  it("never lets the years ahead go negative past the expectancy", () => {
+    const now = 100 * YEAR_MS;
+    expect(reflectionLine(0, now, 80)).toBe(
+      "100 years behind you \u00b7 0 ahead, if the tables hold.",
+    );
+  });
+
+  it("clamps negative lived time (future birth) to zero behind", () => {
+    expect(reflectionLine(YEAR_MS, 0, 80)).toBe(
+      "0 years behind you \u00b7 80 ahead, if the tables hold.",
+    );
+  });
+});
+
+describe("mergeImported", () => {
+  const current = {
+    version: 1,
+    birth: "2000-01-01T00:00",
+    birthZone: "Asia/Tokyo",
+    theme: null,
+    expectancy: 80,
+    mode: "years",
+    typeface: "system",
+    reflection: false,
+  };
+
+  it("copies known keys from the import", () => {
+    const merged = mergeImported(current, {
+      birth: "1990-05-15T09:00",
+      birthZone: "Europe/London",
+      theme: { bg: "#000000" },
+      mode: "days",
+      typeface: "mono",
+      reflection: true,
+    });
+    expect(merged.birth).toBe("1990-05-15T09:00");
+    expect(merged.birthZone).toBe("Europe/London");
+    expect(merged.theme).toEqual({ bg: "#000000" });
+    expect(merged.mode).toBe("days");
+    expect(merged.typeface).toBe("mono");
+    expect(merged.reflection).toBe(true);
+  });
+
+  it("clamps an imported expectancy into range", () => {
+    expect(mergeImported(current, { expectancy: 999 }).expectancy).toBe(150);
+    expect(mergeImported(current, { expectancy: 0 }).expectancy).toBe(1);
+    expect(mergeImported(current, { expectancy: "62" }).expectancy).toBe(62);
+  });
+
+  it("falls back to the system typeface for an unknown value", () => {
+    expect(mergeImported(current, { typeface: "comic-sans" }).typeface).toBe(
+      "system",
+    );
+  });
+
+  it("coerces reflection to a boolean", () => {
+    expect(mergeImported(current, { reflection: 1 }).reflection).toBe(true);
+    expect(mergeImported(current, { reflection: "" }).reflection).toBe(false);
+  });
+
+  it("keeps a non-string birth from corrupting state", () => {
+    expect(mergeImported(current, { birth: 12345 }).birth).toBeNull();
+  });
+
+  it("ignores an unknown mode, keeping the current one", () => {
+    expect(mergeImported(current, { mode: "sideways" }).mode).toBe("years");
+  });
+
+  it("ignores unknown keys entirely", () => {
+    const merged = mergeImported(current, { evil: "payload", foo: 1 });
+    expect(merged).not.toHaveProperty("evil");
+    expect(merged).not.toHaveProperty("foo");
+  });
+
+  it("keeps the current value for any key the import omits", () => {
+    const merged = mergeImported(current, { mode: "weeks" });
+    expect(merged.birth).toBe(current.birth);
+    expect(merged.birthZone).toBe(current.birthZone);
+    expect(merged.expectancy).toBe(current.expectancy);
+    expect(merged.typeface).toBe(current.typeface);
+    expect(merged.reflection).toBe(current.reflection);
+  });
+
+  it("tolerates a non-object import", () => {
+    expect(mergeImported(current, null)).toEqual(current);
+    expect(mergeImported(current, "nope")).toEqual(current);
   });
 });

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -200,6 +200,20 @@ describe("renderSettings", () => {
     resetColors: vi.fn(),
     resetBirthday: vi.fn(),
     closeSettings: vi.fn(),
+    setTypeface: vi.fn(),
+    toggleReflection: vi.fn(),
+    setZone: vi.fn(),
+    exportData: vi.fn(),
+    importData: vi.fn(),
+  });
+
+  const data = (over = {}) => ({
+    theme: null,
+    expectancy: 80,
+    typeface: "system",
+    reflection: false,
+    birthZone: null,
+    ...over,
   });
 
   it("renders one color input per theme key", () => {
@@ -305,5 +319,57 @@ describe("renderSettings", () => {
   it("keeps contrast warnings hidden when colors pass", () => {
     renderSettings(app, actions(), { theme: PRESETS.Void, expectancy: 80 });
     expect(app.querySelector("#warn-count").hidden).toBe(true);
+  });
+
+  it("renders the numeral typeface segment with the active one pressed", () => {
+    renderSettings(app, actions(), data({ typeface: "mono" }));
+    expect(app.querySelector(".segment")).not.toBeNull();
+    expect(
+      app.querySelector('[data-typeface="mono"]').getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      app
+        .querySelector('[data-typeface="system"]')
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("reports typeface changes when a segment button is clicked", () => {
+    const a = actions();
+    renderSettings(app, a, data());
+    app.querySelector('[data-typeface="grotesk"]').click();
+    expect(a.setTypeface).toHaveBeenCalledWith("grotesk");
+  });
+
+  it("reflects the reflection setting on the switch and toggles it", () => {
+    const a = actions();
+    renderSettings(app, a, data({ reflection: true }));
+    const sw = app.querySelector("#reflection-switch");
+    expect(sw.getAttribute("role")).toBe("switch");
+    expect(sw.getAttribute("aria-checked")).toBe("true");
+    sw.click();
+    expect(a.toggleReflection).toHaveBeenCalledOnce();
+  });
+
+  it("preselects the birth zone and reports zone changes", () => {
+    const a = actions();
+    renderSettings(app, a, data({ birthZone: "Asia/Tokyo" }));
+    const zone = app.querySelector("#settings-zone");
+    expect(zone.value).toBe("Asia/Tokyo");
+    const other = [...zone.options]
+      .map((o) => o.value)
+      .find((v) => v !== zone.value);
+    zone.value = other;
+    zone.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(a.setZone).toHaveBeenCalledWith(other);
+  });
+
+  it("wires the data export and import buttons", () => {
+    const a = actions();
+    renderSettings(app, a, data());
+    app.querySelector("#export-data").click();
+    app.querySelector("#import-data").click();
+    expect(a.exportData).toHaveBeenCalledOnce();
+    expect(a.importData).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
Adds four Settings additions, integrated with #41 (settings/counter refactor) and #46 (life-in-weeks) — no duplication or reverts.

**Display section**
- **Numerals** segmented control (System / Grotesk / Mono). Stored as `typeface`; applied via new `applyTypeface()` which sets `--num-font` on `documentElement` (not a body class, so `setScreen()` can't clobber it). `.count` now honours `font-family: var(--num-font, inherit)` and keeps `tabular-nums`.
- **Reflection-line toggle**. When on, the counter shows a pure `reflectionLine()` string as `<p class="reflection">` below the meta (computed once per show; changes yearly).

**Birth Time-zone control** — a Settings `<select>` (`listTimeZones`) re-anchors the birth instant after setup, persisted via `setZone()`.

**Data export/import (JSON)** — export the state to `mortality-settings.json`; import folds a file onto state via pure `mergeImported()` copying only known keys with sanity checks (birth string|null, expectancy clamped, typeface validated → system, reflection coerced boolean, mode kept only if in MODES; unknown keys ignored).

Pure helpers `reflectionLine`/`mergeImported` (tab.js) and `applyTypeface` (store.js) are unit-tested; integration tests cover the segment, switch, and zone control. No new deps, `el()`/no innerHTML, theme-tokened CSS.

**Deferred to future PRs:** WHO country/sex expectancy source + `storage.sync` toggle.