### PR TITLE
Add Light and Dark theme presets

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -105,7 +105,7 @@ the number to carry the weight.
 The surface is deliberately empty. An editorial lower-left composition leaves most of the
 new tab as open space, and depth comes not from shadows or cards but from a single
 time-of-day ambient glow that drifts across the background with the real hour — the light
-in the room, not a UI chrome. Personalization (four-color themes, five curated presets,
+in the room, not a UI chrome. Personalization (four-color themes, seven curated presets,
 adjustable life expectancy) lets the instrument be re-cased without changing what it is.
 
 This system explicitly rejects the loud grammar of productivity software. No gamified
@@ -119,7 +119,7 @@ through restraint and arithmetic, never through props.
 - Editorial stillness — lower-left composition, generous negative space, no cards.
 - Ambient depth, not shadows — a single time-of-day glow is the only atmosphere.
 - Precision typography — tabular figures, a monospace fraction, a single accent point.
-- Calm, contrast-checked color that recolors cleanly across light, dark, and five presets.
+- Calm, contrast-checked color that recolors cleanly across light, dark, and seven presets.
 
 ## 2. Colors
 
@@ -148,10 +148,13 @@ both light and dark and across every user preset.
 
 ### Presets (full alternate cases)
 
-Five contrast-checked themes ship in `store.js`, each setting bg / label / count / accent
-together: **Paper** (`#fafaf8` / oxblood `#b23a2e`), **Void** (`#0a0a0a` / sky `#5cc2ea`),
-**Terminal** (`#0a0f0a` / green `#4ee08a`), **Blueprint** (`#0e1b2a` / blue `#5a9be0`),
-**Amber** (`#1a1512` / amber `#e0a24e`).
+Seven contrast-checked themes ship in `store.js`, each setting bg / label / count / accent
+together. Five are full alternate cases: **Paper** (`#fafaf8` / oxblood `#b23a2e`),
+**Void** (`#0a0a0a` / sky `#5cc2ea`), **Terminal** (`#0a0f0a` / green `#4ee08a`),
+**Blueprint** (`#0e1b2a` / blue `#5a9be0`), **Amber** (`#1a1512` / amber `#e0a24e`). Two
+more — **Light** (`#ffffff` / `#007ea6`) and **Dark** (`#222222` / `#007ea6`) — mirror the
+stylesheet defaults so the shipped light and dark looks are selectable presets, giving
+people a one-tap way back to the baseline.
 
 ### Named Rules
 

--- a/src/store.js
+++ b/src/store.js
@@ -20,7 +20,22 @@ export const MODES = [
 
 // Curated full-theme presets. Every set is contrast-checked (count & label ≥4.5:1
 // on bg, accent ≥3:1). Applying one writes all four THEME_KEYS at once.
+// Light and Dark mirror the stylesheet defaults in tab.css (:root and the
+// prefers-color-scheme: dark block) so the shipped looks are selectable presets,
+// letting anyone return to them after trying another preset or custom colors.
 export const PRESETS = {
+  Light: {
+    bg: "#ffffff",
+    label: "#6f747a",
+    count: "#494949",
+    accent: "#007ea6",
+  },
+  Dark: {
+    bg: "#222222",
+    label: "#898f97",
+    count: "#b0b5b9",
+    accent: "#007ea6",
+  },
   Paper: {
     bg: "#fafaf8",
     label: "#5f6469",

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
   THEME_KEYS,
   MODES,
@@ -67,6 +69,42 @@ describe("PRESETS accessibility invariants", () => {
       expect(contrast(preset.accent, preset.bg)).toBeGreaterThanOrEqual(3);
     });
   }
+});
+
+describe("Light and Dark presets mirror the stylesheet defaults", () => {
+  // These two presets duplicate the tab.css defaults so the shipped light and
+  // dark looks are selectable. This fails if either drifts out of sync.
+  const css = readFileSync(resolve(process.cwd(), "src/tab.css"), "utf8");
+
+  function parseVars(body) {
+    const vars = {};
+    for (const m of body.matchAll(/--([\w-]+):\s*([^;]+);/g)) {
+      vars[m[1]] = m[2].trim().toLowerCase();
+    }
+    return vars;
+  }
+
+  const rootVars = parseVars(css.match(/:root\s*\{([^}]*)\}/)[1]);
+  const darkVars = parseVars(
+    css.match(
+      /@media \(prefers-color-scheme: dark\)\s*\{\s*:root\s*\{([^}]*)\}/,
+    )[1],
+  );
+
+  it("Light matches the base :root theme keys", () => {
+    for (const key of THEME_KEYS) {
+      expect(PRESETS.Light[key].toLowerCase()).toBe(rootVars[key]);
+    }
+  });
+
+  it("Dark matches the prefers-color-scheme: dark theme keys", () => {
+    for (const key of THEME_KEYS) {
+      // Dark inherits any key it doesn't override from :root (e.g. accent).
+      expect(PRESETS.Dark[key].toLowerCase()).toBe(
+        darkVars[key] ?? rootVars[key],
+      );
+    }
+  });
 });
 
 describe("bestOnColor", () => {


### PR DESCRIPTION
## What & why

The shipped **light** and **dark** color schemes lived only in `tab.css`, so once someone applied another preset or picked custom colors, there was no easy way back to the default look. This adds them as selectable presets.

## Changes

- **`src/store.js`** — Added `Light` (`#ffffff` bg / `#007ea6` accent) and `Dark` (`#222222` bg / `#007ea6` accent) as the first two entries in `PRESETS`, mirroring the `tab.css` `:root` and `prefers-color-scheme: dark` defaults exactly. They render as swatches and light up as active when they match the current colors.
- **`test/store.test.js`** — Added a drift-detection test that parses `tab.css` and fails if either preset diverges from the stylesheet defaults.
- **`DESIGN.md`** — Updated the preset count (five → seven) and documented the two default-mirroring presets.

## Verification

- All **118 tests pass** (116 + 2 new), including the accessibility-contrast invariants that now cover Light/Dark (both clear 4.5:1 text / 3:1 accent on their background).
- Prettier formatting clean.
- Rendered the settings screen to confirm both swatches appear first with correct colors and that the active-state highlight works.

Users can still hit **Reset colors** to return to system-following (auto light/dark) behavior; the new presets set an explicit fixed theme.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>