### PR TITLE
Add workflow prefs to Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,3 +28,10 @@ Quick reference:
   `prefers-reduced-motion` path for every animation · **WCAG 2.1 AA**.
 
 To iterate visually, run `/impeccable live` (pre-configured for `src/tab.html`).
+
+## Workflow
+
+- **UI changes:** always open the integrated browser (preview `src/tab.html`, or the dev
+  server) so the change can be tried out live before it's finalized.
+- **Pull requests:** always capture screenshots of the affected UI and attach them to the
+  PR description.


### PR DESCRIPTION
## What

Adds a **Workflow** section to `.github/copilot-instructions.md` capturing two working preferences so they apply to all future Copilot sessions on this repo:

- **UI changes:** always open the integrated browser (preview `src/tab.html`, or the dev server) so the change can be tried out live before it's finalized.
- **Pull requests:** always capture screenshots of the affected UI and attach them to the PR description.

## Why

These were stated as personal working preferences. Session-state files don't carry over between sessions, so persisting them in the repo-level instructions file (which is auto-loaded every session) makes them stick — and once merged to `master`, every new session picks them up.

## Screenshots

N/A — this change only touches an instructions markdown file; no UI is affected.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>