### PR TITLE
Consolidate corner controls and fix weeks back-navigation

### DIFF
--- a/src/tab.css
+++ b/src/tab.css
@@ -419,11 +419,21 @@ footer {
   display: block;
 }
 
-/* Second corner button (life-in-weeks entry, weeks-view back): reuses every
-   .gear rule, just mirrored to the top-left. */
-.gear.corner-left {
-  right: auto;
-  left: 0.75rem;
+/* Top-right control cluster, shared by the counter and life-in-weeks screens.
+   The gear keeps the exact corner; the button to its left is a same-slot toggle
+   (opens the weeks view from the counter, returns from it on the weeks screen),
+   so you always leave from where you entered. Buttons go static inside the
+   fixed cluster. */
+.corner-controls {
+  position: fixed;
+  top: 0.75rem;
+  right: 0.75rem;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.corner-controls .gear {
+  position: static;
 }
 
 .settings {

--- a/src/tab.js
+++ b/src/tab.js
@@ -543,6 +543,17 @@ async function init() {
   state = await load();
   applyTheme(state.theme);
   applyTypeface(state.typeface);
+
+  // Escape returns to the counter from the weeks and settings screens, so those
+  // views are dismissable from the keyboard, not only via the corner control.
+  document.addEventListener("keydown", (event) => {
+    if (event.key !== "Escape" || !state || !state.birth) return;
+    const screen = document.body.className;
+    if (screen === "screen-weeks" || screen === "screen-settings") {
+      showCounter();
+    }
+  });
+
   setupAmbient();
   if (state.birth) showCounter();
   else showSetup();

--- a/src/views.js
+++ b/src/views.js
@@ -208,7 +208,7 @@ export function renderCounter(
   const weeksBtn = el(
     "button",
     {
-      class: "gear corner-left",
+      class: "gear",
       id: "weeks-btn",
       title: "Life in weeks",
       "aria-label": "Life in weeks",
@@ -250,7 +250,14 @@ export function renderCounter(
   if (reflection) {
     counter.append(el("p", { class: "reflection" }, reflection));
   }
-  app.replaceChildren(weeksBtn, gear, counter);
+  // Both chrome controls share one top-right cluster so the rest of the canvas
+  // (and the whole top-left) stays clear — the gear keeps the corner, the
+  // life-in-weeks toggle sits just inboard of it.
+  const cornerControls = el("div", { class: "corner-controls" }, [
+    weeksBtn,
+    gear,
+  ]);
+  app.replaceChildren(cornerControls, counter);
 
   gear.addEventListener("click", openSettings);
   weeksBtn.addEventListener("click", openWeeks);
@@ -508,7 +515,7 @@ export function renderWeeks(
   const backBtn = el(
     "button",
     {
-      class: "gear corner-left",
+      class: "gear",
       id: "weeks-back",
       title: "Back",
       "aria-label": "Back",
@@ -548,7 +555,13 @@ export function renderWeeks(
     ]),
   ]);
 
-  app.replaceChildren(backBtn, gear, wrap);
+  // Same top-right cluster as the counter: the Back arrow takes the exact slot
+  // the grid toggle used to enter this view, so you leave from where you came in.
+  const cornerControls = el("div", { class: "corner-controls" }, [
+    backBtn,
+    gear,
+  ]);
+  app.replaceChildren(cornerControls, wrap);
 
   backBtn.addEventListener("click", back);
   gear.addEventListener("click", openSettings);

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -417,3 +417,35 @@ describe("life in weeks", () => {
     expect(document.body.className).toBe("screen-counter");
   });
 });
+
+describe("keyboard dismissal", () => {
+  it("returns to the counter when Escape is pressed in the weeks view", async () => {
+    seed({ birth: "2000-01-01T00:00", expectancy: 80 });
+    await boot();
+
+    document.querySelector('[aria-label="Life in weeks"]').click();
+    expect(document.body.className).toBe("screen-weeks");
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(document.body.className).toBe("screen-counter");
+  });
+
+  it("returns to the counter when Escape is pressed in settings", async () => {
+    seed({ birth: "2000-01-01T00:00" });
+    await boot();
+
+    document.querySelector('[aria-label="Settings"]').click();
+    expect(document.body.className).toBe("screen-settings");
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(document.body.className).toBe("screen-counter");
+  });
+
+  it("ignores Escape on the setup screen, where there is no counter yet", async () => {
+    await boot();
+    expect(document.body.className).toBe("screen-setup");
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(document.body.className).toBe("screen-setup");
+  });
+});


### PR DESCRIPTION
## What & why

The life-in-weeks toggle and the settings gear previously sat in **opposite** top corners, and you entered the weeks view from the top-right but left it via a top-left Back arrow — a spatial mismatch that made toggling back awkward. This consolidates both chrome controls into a single **top-right cluster** and makes the navigation reversible from where you entered.

## Changes

- **Shared corner cluster** (`.corner-controls`): the settings gear keeps the exact corner; the second button sits just inboard of it with a `0.25rem` gap. Shared by the counter and weeks screens, so the top-left and the rest of the canvas stay clear.
- **Counter screen**: the life-in-weeks toggle (`▦`) moves from the top-left into the cluster, next to the gear.
- **Weeks screen**: the Back arrow (`←`) now occupies the exact slot the toggle used to enter the view — you leave from where you came in.
- **Esc to exit**: a single document-level `keydown` listener returns to the counter from the weeks and settings screens (previously there was no keyboard exit at all). Guarded on `state.birth`.

## Design

Follows the "Quiet Instrument" register — no new colors, fonts, or radii, and the accent still marks a single live point. Reuses every existing `.gear` rule; buttons go `position: static` inside the fixed cluster.

## Testing

- `npm test` — **148/148 pass** (added 3 integration tests: Esc-dismiss from weeks, from settings, and no-op during setup).
- `npx prettier --check` — clean.
- Live-verified in a headless browser: on the weeks screen the Back button sits at the same slot the grid toggle uses on the counter (left 627 / top 12), and Esc returns to the counter from both screens.

## Screenshots

Captured and reviewed during development:
- **Counter** — grid toggle moved from the top-left into the top-right cluster, next to the gear.
- **Life in weeks** — Back arrow moved from the top-left into the same top-right cluster.