### PR TITLE
Reconcile tab.css values with the design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,6 @@ pnpm-debug.log*
 /artifacts
 
 # impeccable design-skill local cache
-.impeccable/
+# Keep only the shared, reviewable config (detector ignores) tracked.
+.impeccable/*
+!.impeccable/config.json

--- a/.impeccable/config.json
+++ b/.impeccable/config.json
@@ -1,0 +1,20 @@
+{
+  "detector": {
+    "ignoreRules": [],
+    "ignoreFiles": [],
+    "ignoreValues": [
+      {
+        "rule": "design-system-color",
+        "value": "#000",
+        "reason": "mask-image alpha stop on .count .fraction (linear-gradient fade); only the alpha channel is used, not a paint color",
+        "createdAt": "2026-07-10T04:21:33.785Z"
+      },
+      {
+        "rule": "design-system-color",
+        "value": "rgba(0, 0, 0, 0.28)",
+        "reason": "mask-image alpha stop on .count .fraction (linear-gradient fade); only the alpha channel is used, not a paint color",
+        "createdAt": "2026-07-10T04:21:37.956Z"
+      }
+    ]
+  }
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -46,11 +46,17 @@ typography:
     fontSize: "0.4em"
     fontWeight: 500
     letterSpacing: "0.01em"
+  numeral-grotesk:
+    fontFamily: "'Avenir Next', 'Helvetica Neue', Arial, sans-serif"
+    fontWeight: 600
+    fontFeature: "'tnum' 1"
 rounded:
+  2xs: "1px"
   xs: "2px"
   sm: "0.25rem"
   md: "0.4rem"
   lg: "0.5rem"
+  full: "999px"
 spacing:
   xs: "0.35rem"
   sm: "0.5rem"
@@ -189,6 +195,20 @@ sub-scale rather than a second typeface.
 - **Caption** (400, `0.72rem`, `letter-spacing: 0.1em`, UPPERCASE): The meta row (born date,
   percentage) and settings section labels.
 
+### Numeral Typeface (user-selectable)
+
+The big count offers three numeral typefaces, chosen in Settings and applied as an inline
+`--num-font` custom property by `applyTypeface()` in `store.js` (`TYPEFACES = ["system",
+"grotesk", "mono"]`). All three keep `tabular-nums` + `"tnum" 1`, and only the figures
+change — the rest of the interface always stays on the display sans.
+
+- **System** (default): clears `--num-font`, so the number inherits the display face
+  (Avenir). The quietest option; the count matches the labels around it.
+- **Grotesk**: `'Avenir Next', 'Helvetica Neue', Arial, sans-serif` — a slightly more
+  geometric grotesque for the figures only.
+- **Mono**: `ui-monospace, 'SF Mono', Menlo, Consolas, monospace` — the same monospace as
+  the fraction sub-scale, turning the whole reading into an instrument-panel readout.
+
 ### Named Rules
 
 **The Tabular Rule.** Any figure that updates in place is `tabular-nums`. A number that
@@ -256,6 +276,23 @@ never a bounce, never a glow-for-flavor.
 - A `2px` hairline track (`.progress`) in a translucent muted tone with an accent fill
   (`.progress-fill`) driven by `transform: scaleX(fraction)` over `0.6s` ease-out-expo.
   Paired with a caption row: born date at left, "% of N yrs lived" at right.
+
+### The Reflection Toggle
+
+- The Settings on/off control (`.switch`): a `2.6 × 1.5rem` fully-rounded **pill**
+  (`rounded.full`, `999px`) with a `1px` hairline border and a circular knob that slides
+  left→right on toggle; the track fills with accent when on. `transition: 0.15s ease`. The
+  pill is the one fully-rounded shape in the system — it reads instantly as a switch and is
+  reserved for that control.
+
+### Life in Weeks (view)
+
+- A full-screen calendar where each row is a year and each cell a week: a 52-column grid of
+  `1px`-radius (`rounded.2xs` hairline) squares with `aspect-ratio: 1` and `2px` gaps, in
+  three tonal states — lived (`count`-tinted), now (accent), future (translucent muted). The
+  legend swatches share the same hairline radius. The `2xs` (`1px`) corner just softens the
+  hard edge across the ~4,000-cell field without rounding the cells into dots — anything
+  larger reads as chips and breaks the plotted-grid feel.
 
 ## 6. Do's and Don'ts
 


### PR DESCRIPTION
## What & why

`src/tab.css` carried six pre-existing **impeccable** design-hook findings. This PR clears all six **without changing a single rendered pixel** — each is resolved by documenting the *intentional* design in `DESIGN.md` or by suppressing a genuine false positive. **No `.css`/`.js`/`.html` is touched**; the diff is docs + detector config only.

Independent of #51 (corner-control placement) — no overlap.

## Findings & resolutions

| # | Finding (selector) | Kind | Resolution |
|---|---|---|---|
| 1 | `"Avenir Next"` — `.segment button.grotesk`, applied for real by `applyTypeface("grotesk")` → `--num-font` | font (warning) | **Documented.** Added a `numeral-grotesk` typography role (the Avenir Next stack) + a *Numeral Typeface* prose subsection covering all three user-selectable faces (system / grotesk / mono). A real feature (`TYPEFACES` in `store.js`), not drift. |
| 2 | `#000` — `mask-image`/`-webkit-mask-image` on `.count .fraction` | color (advisory) | **Suppressed (false positive).** A mask *alpha* stop, not a paint color — only the alpha channel is used in a CSS mask. `hooks ignore-value`. |
| 3 | `rgba(0, 0, 0, 0.28)` — same mask gradient | color (advisory) | **Suppressed (false positive).** Same reasoning; distinct alpha key, so a separate ignore-value. |
| 4 | `999px` — `.switch` reflection-line pill toggle | radius (advisory) | **Tokenized.** Added `rounded.full: "999px"` + a *Reflection Toggle* component entry. CSS value unchanged. |
| 5 | `1px` — `.weeks-grid i` (week cells) | radius (advisory) | **Tokenized.** Added `rounded.2xs: "1px"` hairline token + a *Life in Weeks* component entry. |
| 6 | `1px` — `.weeks-legend i` (legend swatches) | radius (advisory) | Same `2xs` hairline token. |

### On the 1px hairline (5 & 6)
Live-verified in the browser: on the ~10px week cells, 1px is the intended hairline — it softens the hard corner without rounding cells into dots. Snapping to the existing `xs` (2px) would visibly round them and break the plotted-grid feel, so per impeccable's *never change intentional design to satisfy the hook*, the value is **documented, not changed**.

### Optional box-shadow ring — evaluated, skipped
`.weeks-grid i.now` uses `box-shadow: 0 0 0 1px var(--accent)` as an outward accent ring on the accent-filled "now" cell (the detector does **not** flag it). The suggested `outline: 1px solid var(--accent); outline-offset: -1px` rewrite would draw the ring *inside* the cell — invisible against its own accent fill, i.e. a visual change. Left as-is.

## Verification

| Gate | Result |
|---|---|
| `detect.mjs src/tab.css` | **0 findings** |
| `detect.mjs src` | **0 findings** |
| `npm test` | **145 / 145** |
| `prettier --check .` | clean |

Files changed: `DESIGN.md` (frontmatter tokens + prose), `.impeccable/config.json` (the two shared mask-color ignore-values), and a narrowed `.gitignore` so the shared detector config travels with the repo and stays reviewable.

## Screenshots
This PR makes **no visual change** (docs/config only), so no screenshots are embedded. The Settings screen (reflection pill + Grotesk numerals) and Life-in-weeks screen (hairline cells) were captured and verified live during review.