### PR TITLE
ci: track main instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ name: "ci"
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   workflow_call:
 
 permissions:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,12 +1,12 @@
 name: "pre-release"
 
-# Rolling development build. Every push to master runs the full quality gate and,
+# Rolling development build. Every push to main runs the full quality gate and,
 # if green, refreshes the single "latest" pre-release with the freshly packaged
 # extension. Pull requests are covered by ci.yml, so this only runs post-merge.
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What & why

The repository's default branch was renamed from `master` to `main`. This updates the workflow branch filters so CI and the rolling pre-release keep firing on the new default.

## Changes

- `.github/workflows/ci.yml` — `pull_request` filter `[master]` → `[main]`
- `.github/workflows/pre-release.yml` — `push` filter `[master]` → `[main]`, and the descriptive comment now says "push to main"

## Repo administration already applied (outside this diff)

- Renamed `master` → `main` via GitHub's rename API; `master` no longer exists and `main` is the default branch.
- The protection ruleset targets `~DEFAULT_BRANCH`, so it now enforces on `main` automatically (code-owner PR review, required Prettier/Vitest/Pack checks, Copilot review). Renamed the ruleset "Protect master" → "Protect main".
- No open PRs required retargeting (the only prior PR, #51, is closed).

The `images/icon.svg` "editable master" reference is intentionally left alone — it refers to the source SVG, not a git branch.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
