### PR TITLE
Drop the 'attach screenshots to every PR' instruction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,5 +33,8 @@ To iterate visually, run `/impeccable live` (pre-configured for `src/tab.html`).
 
 - **UI changes:** always open the integrated browser (preview `src/tab.html`, or the dev
   server) so the change can be tried out live before it's finalized.
-- **Pull requests:** always capture screenshots of the affected UI and attach them to the
-  PR description.
+- **Pull requests:** describe UI changes in words in the PR description — do **not** embed
+  screenshots. GitHub's attachment CDN can't be reached from the CLI, so screenshots would
+  otherwise require committing image files or parking them on a throwaway asset branch;
+  never do that. If a reviewer wants visual proof, attach it by hand via drag-and-drop in
+  the browser.


### PR DESCRIPTION
## Why

The Copilot workflow instructions said to *"always capture screenshots of the affected UI and attach them to the PR description."* In practice that isn't achievable from the CLI: GitHub's image/attachment CDN (`user-attachments`) has **no API** — it's only reachable via drag-and-drop / paste in the browser, authenticated by a session cookie + CSRF token, not a PAT.

Following the rule literally forced ugly workarounds — committing PNGs to the repo or parking them on a throwaway `pr-assets` branch and embedding `raw.githubusercontent.com` URLs — which then have to be cleaned up and leave broken images behind when the branch is deleted.

## Change

Replace the bullet with guidance that matches what's actually possible from the CLI:

- Describe UI changes **in words** in the PR description.
- Keep verifying UI changes **live in the browser** (the existing bullet above is unchanged).
- **Don't** embed screenshots or push image files to host them.
- If a reviewer wants visual proof, attach it **by hand** via drag-and-drop in the browser.

Docs-only change to `.github/copilot-instructions.md`; no code touched. The project's own README theme screenshots are unaffected.