### PR TITLE
Add actuarial expectancy and a next-birthday countdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ A browser extension that replaces your new tab page with a live counter of your 
 ## Features
 
 - **Live age counter** — ticks in real time, down to fractional years.
-- **Multiple units** — switch between age, days lived, weeks lived, weeks left, and
-  percent of an expected lifetime elapsed.
+- **Multiple units** — switch between age, calendar age, a live next-birthday
+  countdown, days or weeks lived, time left, and percent of an expected lifetime
+  elapsed.
 - **Personalization** — light and dark themes that follow your system, color presets
   and custom colors, and an adjustable life expectancy.
 - **Accessible and calm** — WCAG 2.1 AA, a `prefers-reduced-motion` path, and full

--- a/src/lifetable.js
+++ b/src/lifetable.js
@@ -1,0 +1,92 @@
+// Actuarial life-expectancy data + estimator. Zero dependencies, pure functions.
+//
+// Source: U.S. Social Security Administration, "Actuarial Life Table" —
+// Period Life Table, 2023 (as used in the 2026 Trustees Report).
+// https://www.ssa.gov/oact/STATS/table4c6.html
+//
+// Works of the U.S. federal government are in the PUBLIC DOMAIN (17 U.S.C. Sec.
+// 105), so this table is safe to embed under the project's MIT, zero-dependency
+// ethos. (WHO GHO life-expectancy data is deliberately NOT used: its
+// CC BY-NC-SA licensing is incompatible with embedding here.)
+//
+// MALE and FEMALE below are the e(x) column — the expectation of remaining years
+// of life at exact integer age x — for x = 0..119. Spot-check values from the
+// source table: MALE e(0)=75.79, e(65)=18.12, e(100)=2.04; FEMALE e(0)=81.06,
+// e(65)=20.66, e(100)=2.23. The table's own invariants hold across every age:
+// e(x) is non-increasing, the total x+e(x) is non-decreasing, and FEMALE e(x) is
+// >= MALE e(x) everywhere.
+
+/** Male expectation of remaining life e(x), by integer age x = 0..119 (years). */
+export const MALE = [
+  75.79, 75.25, 74.28, 73.31, 72.33, 71.34, 70.35, 69.36, 68.37, 67.38, 66.39,
+  65.39, 64.4, 63.41, 62.43, 61.45, 60.48, 59.51, 58.56, 57.62, 56.69, 55.76,
+  54.83, 53.9, 52.98, 52.06, 51.14, 50.23, 49.32, 48.41, 47.5, 46.6, 45.7,
+  44.81, 43.91, 43.02, 42.13, 41.24, 40.36, 39.47, 38.59, 37.71, 36.83, 35.95,
+  35.08, 34.21, 33.34, 32.48, 31.62, 30.76, 29.9, 29.05, 28.21, 27.38, 26.55,
+  25.73, 24.92, 24.12, 23.34, 22.56, 21.79, 21.04, 20.29, 19.56, 18.83, 18.12,
+  17.41, 16.71, 16.02, 15.34, 14.66, 14.0, 13.34, 12.69, 12.05, 11.42, 10.8,
+  10.19, 9.61, 9.04, 8.5, 7.97, 7.46, 6.97, 6.5, 6.04, 5.61, 5.2, 4.81, 4.45,
+  4.11, 3.8, 3.5, 3.23, 2.99, 2.77, 2.58, 2.41, 2.27, 2.15, 2.04, 1.93, 1.83,
+  1.72, 1.63, 1.54, 1.45, 1.36, 1.28, 1.2, 1.13, 1.05, 0.98, 0.92, 0.85, 0.79,
+  0.74, 0.68, 0.63, 0.58,
+];
+
+/** Female expectation of remaining life e(x), by integer age x = 0..119 (years). */
+export const FEMALE = [
+  81.06, 80.48, 79.51, 78.53, 77.54, 76.55, 75.56, 74.57, 73.58, 72.59, 71.59,
+  70.6, 69.61, 68.62, 67.63, 66.64, 65.66, 64.67, 63.69, 62.72, 61.74, 60.77,
+  59.8, 58.83, 57.86, 56.9, 55.93, 54.97, 54.0, 53.04, 52.08, 51.13, 50.18,
+  49.23, 48.28, 47.34, 46.39, 45.45, 44.51, 43.58, 42.64, 41.71, 40.78, 39.86,
+  38.93, 38.01, 37.1, 36.18, 35.27, 34.36, 33.45, 32.55, 31.66, 30.77, 29.89,
+  29.01, 28.14, 27.28, 26.42, 25.57, 24.73, 23.9, 23.08, 22.27, 21.46, 20.66,
+  19.87, 19.08, 18.3, 17.53, 16.76, 16.01, 15.26, 14.53, 13.81, 13.1, 12.41,
+  11.73, 11.08, 10.44, 9.82, 9.22, 8.64, 8.08, 7.54, 7.02, 6.53, 6.05, 5.61,
+  5.19, 4.8, 4.44, 4.1, 3.79, 3.5, 3.23, 2.99, 2.77, 2.57, 2.39, 2.23, 2.08,
+  1.94, 1.82, 1.7, 1.59, 1.48, 1.38, 1.29, 1.2, 1.13, 1.05, 0.98, 0.92, 0.85,
+  0.79, 0.74, 0.68, 0.63, 0.58,
+];
+
+/**
+ * Unisex expectation of remaining life: the simple average of MALE and FEMALE at
+ * each age. Used when the user hasn't shared a sex at birth.
+ */
+export const UNISEX = MALE.map((m, i) => (m + FEMALE[i]) / 2);
+
+/** The e(x) table for a given sex; unknown/null falls back to UNISEX. */
+function tableFor(sex) {
+  if (sex === "male") return MALE;
+  if (sex === "female") return FEMALE;
+  return UNISEX;
+}
+
+/**
+ * Estimate the total expected age at death for someone who has ALREADY attained
+ * `ageYears`, conditioned on an optional sex at birth. Life expectancy is
+ * conditional on survival: e(x) is the expected REMAINING years at exact age x,
+ * so the total expected age is x + e(x), which rises with attained age (a 70-year
+ * old outlives the at-birth average). e(x) is linearly interpolated between
+ * integer ages for smoothness, and the final total is rounded to a whole year.
+ *
+ * The attained age is clamped to the table's bounds [0, last index] before
+ * lookup; the result is guaranteed to be >= the attained age and to sit within
+ * the app's supported expectancy band [1, 150].
+ *
+ * @param {number} ageYears Attained age in years (may be fractional).
+ * @param {"male"|"female"|null} [sex] Sex at birth; null/omitted uses UNISEX.
+ * @returns {number} Whole-number total expected age at death.
+ */
+export function estimateExpectancy(ageYears, sex) {
+  const table = tableFor(sex);
+  const last = table.length - 1;
+  const age = Math.min(
+    last,
+    Math.max(0, Number.isFinite(ageYears) ? ageYears : 0),
+  );
+  const lo = Math.floor(age);
+  const hi = Math.min(last, lo + 1);
+  // Interpolate e(x) between the two bracketing integer ages.
+  const ex = table[lo] + (table[hi] - table[lo]) * (age - lo);
+  const total = Math.round(age + ex);
+  // Never below the person's current age; keep inside the app's clamp [1, 150].
+  return Math.min(150, Math.max(1, Math.ceil(age), total));
+}

--- a/src/store.js
+++ b/src/store.js
@@ -16,6 +16,7 @@ export const TYPEFACES = ["system", "grotesk", "mono"];
 export const MODES = [
   "years",
   "calendar",
+  "birthday",
   "days",
   "weeks",
   "yearsLeft",

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,7 @@
 // Persistence + theming. No dependencies, runs directly in the browser.
 
 import { detectZone } from "./time.js";
+import { estimateExpectancy } from "./lifetable.js";
 
 const KEY = "mortality";
 
@@ -78,10 +79,45 @@ const DEFAULTS = {
   birthZone: null,
   theme: null,
   expectancy: 80,
+  expectancySource: "estimate",
+  sex: null,
   mode: "years",
   typeface: "system",
   reflection: false,
 };
+
+/**
+ * Clamp a life-expectancy value to the supported whole-year band [1, 150],
+ * parsing leading integers out of strings. Non-numeric input falls back to 80
+ * (the historical default). Lives here — not in the controller — so both the
+ * store's resolver and the controller can share one definition without a
+ * circular import (tab.js re-exports it).
+ * @param {unknown} value
+ * @returns {number}
+ */
+export function clampExpectancy(value) {
+  const n = parseInt(value, 10);
+  if (!Number.isFinite(n)) return 80;
+  return Math.min(150, Math.max(1, n));
+}
+
+/**
+ * Resolve the life expectancy actually in force for a given attained age. When
+ * the user pins a custom number we honour it verbatim (clamped); otherwise we
+ * derive an actuarial estimate from their age and optional sex at birth. Falls
+ * back to the clamped custom value whenever the age can't be computed (e.g. no
+ * birthday yet), so the counter always has a sane denominator. Pure.
+ * @param {{expectancySource?: string, expectancy?: unknown, sex?: string|null}} state
+ * @param {number} ageYears Attained age in years (may be fractional or NaN).
+ * @returns {number}
+ */
+export function effectiveExpectancy(state, ageYears) {
+  const source = state && state.expectancySource;
+  const custom = clampExpectancy(state && state.expectancy);
+  if (source === "custom") return custom;
+  if (!Number.isFinite(ageYears)) return custom;
+  return estimateExpectancy(ageYears, state ? state.sex : null);
+}
 
 // Extension storage.local persists across the privacy/history clearing that can
 // silently wipe localStorage on extension pages (Firefox especially, issue #16).
@@ -156,12 +192,33 @@ function backfillZone(state) {
 }
 
 /**
+ * Migrate a pre-existing record onto the actuarial-expectancy model. Only a
+ * BRAND-NEW install (raw === null) defaults `expectancySource` to "estimate";
+ * any record that already lived on disk before this feature lacked the field, so
+ * it's pinned to "custom" — preserving the exact number that user has always
+ * seen (their flat 80, or whatever they set) rather than silently swapping in an
+ * age-based estimate on update. `sex` is backfilled to null when absent. Returns
+ * the state unchanged (same reference) when there is nothing to migrate.
+ * @param {object} state  State already merged over DEFAULTS.
+ * @param {object|null|undefined} raw  The record as read from storage/legacy.
+ */
+function migrateExpectancy(state, raw) {
+  if (!raw) return state; // brand-new install → keep the DEFAULTS estimate
+  const patch = {};
+  if (!("expectancySource" in raw)) patch.expectancySource = "custom";
+  if (!("sex" in raw)) patch.sex = null;
+  return Object.keys(patch).length ? { ...state, ...patch } : state;
+}
+
+/**
  * Load persisted state, applying defaults and migrating older localStorage data
  * (the "mortality" JSON blob or the legacy "dob" string) on first run. Records
  * that predate timezone support get their birthZone backfilled with the
  * detected zone (see backfillZone) so the birth instant is anchored going
- * forward without changing the age shown today.
- * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, mode: string, typeface: string, reflection: boolean }>}
+ * forward without changing the age shown today. Records that predate the
+ * actuarial-expectancy feature keep their flat number by being pinned to a
+ * "custom" expectancy source (see migrateExpectancy).
+ * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, expectancySource: string, sex: string|null, mode: string, typeface: string, reflection: boolean }>}
  */
 export async function load() {
   let stored;
@@ -174,7 +231,10 @@ export async function load() {
   if (!stored) {
     const legacy = readLegacy();
     if (legacy) {
-      const migrated = backfillZone({ ...DEFAULTS, ...legacy });
+      const migrated = migrateExpectancy(
+        backfillZone({ ...DEFAULTS, ...legacy }),
+        legacy,
+      );
       await save(migrated);
       // Only clear localStorage when a real extension store now owns the data;
       // under the localStorage shim, KEY *is* the store we just wrote to.
@@ -184,7 +244,8 @@ export async function load() {
   }
 
   const state = { ...DEFAULTS, ...(stored || {}) };
-  const backfilled = backfillZone(state);
+  const migrated = migrateExpectancy(state, stored);
+  const backfilled = backfillZone(migrated);
   if (backfilled !== state) await save(backfilled);
   return backfilled;
 }

--- a/src/tab.css
+++ b/src/tab.css
@@ -482,6 +482,17 @@ footer {
   color: var(--input-text);
 }
 
+.row select {
+  padding: 0.25rem 0.5rem;
+  font-size: 1rem;
+  font-family: inherit;
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+  background-color: var(--input-bg);
+  color: var(--input-text);
+  cursor: pointer;
+}
+
 .settings-label {
   margin: 0.4rem 0 0;
   color: var(--label);

--- a/src/tab.css
+++ b/src/tab.css
@@ -217,6 +217,12 @@ body.screen-counter #app {
   margin-right: 0;
 }
 
+/* Four-part birthday readout stays on one calm line at narrow tab widths. */
+.count.birthday-count {
+  font-size: clamp(2.25rem, 11vw, 5.5rem);
+  white-space: nowrap;
+}
+
 /* Life-elapsed meter + editorial anchor line under the number. */
 .meta {
   margin-top: 1.15rem;

--- a/src/tab.js
+++ b/src/tab.js
@@ -6,6 +6,8 @@ import {
   applyTheme,
   applyTypeface,
   cssDefault,
+  clampExpectancy,
+  effectiveExpectancy,
   THEME_KEYS,
   MODES,
   TYPEFACES,
@@ -24,6 +26,7 @@ import {
   isValidZone,
   parseBirthParts,
 } from "./time.js";
+import { estimateExpectancy } from "./lifetable.js";
 import { el } from "./dom.js";
 
 const YEAR_MS = 31556900000; // milliseconds per year (preserved from v1.2)
@@ -61,10 +64,16 @@ function setScreen(name) {
   document.body.className = name ? `screen-${name}` : "";
 }
 
-export function clampExpectancy(value) {
-  const n = parseInt(value, 10);
-  if (!Number.isFinite(n)) return 80;
-  return Math.min(150, Math.max(1, n));
+// clampExpectancy now lives in store.js (so the store's resolver and this
+// controller share one definition without a circular import); re-exported here
+// because it's part of tab.js's public test surface.
+export { clampExpectancy };
+
+// Attained age in whole-and-fractional years for a stored birth, or NaN when the
+// birth can't be parsed. Shared by the counter and weeks screens so both feed the
+// same number into effectiveExpectancy.
+function ageYearsFrom(bornMs, nowMs) {
+  return Number.isFinite(bornMs) ? (nowMs - bornMs) / YEAR_MS : NaN;
 }
 
 export function formatBorn(birth) {
@@ -117,6 +126,14 @@ export function mergeImported(current, imported) {
   if ("birthZone" in src) known.birthZone = src.birthZone;
   if ("theme" in src) known.theme = src.theme;
   if ("expectancy" in src) known.expectancy = clampExpectancy(src.expectancy);
+  if ("expectancySource" in src)
+    known.expectancySource = ["estimate", "custom"].includes(
+      src.expectancySource,
+    )
+      ? src.expectancySource
+      : current.expectancySource;
+  if ("sex" in src)
+    known.sex = src.sex === "male" || src.sex === "female" ? src.sex : null;
   if ("mode" in src && MODES.includes(src.mode)) known.mode = src.mode;
   if ("typeface" in src)
     known.typeface = TYPEFACES.includes(src.typeface) ? src.typeface : "system";
@@ -127,12 +144,13 @@ export function mergeImported(current, imported) {
 function showSetup() {
   stopTimer();
   setScreen("setup");
-  renderSetup(app, { start }, state.birth, state.birthZone);
+  renderSetup(app, { start }, state.birth, state.birthZone, state.sex);
 }
 
-function start(birth, zone) {
+function start(birth, zone, sex) {
   state.birth = birth;
   state.birthZone = zone || detectZone();
+  state.sex = sex === "male" || sex === "female" ? sex : null;
   save(state);
   showCounter();
 }
@@ -146,7 +164,13 @@ function showCounter() {
   // The same effective zone drives the calendar-age breakdown below.
   const zone = isValidZone(state.birthZone) ? state.birthZone : detectZone();
   const bornMs = birthInstantMs(state.birth, zone);
-  const expectancy = clampExpectancy(state.expectancy);
+  // Resolve expectancy for the attained age: a custom number is honoured
+  // verbatim, otherwise it's an actuarial estimate that legitimately rises a
+  // little as the user ages (recomputed here, once per counter show).
+  const expectancy = effectiveExpectancy(
+    state,
+    ageYearsFrom(bornMs, Date.now()),
+  );
   let mode = MODES.includes(state.mode) ? state.mode : "years";
 
   // The reflection line changes at most once a year, so compute it once on show
@@ -304,7 +328,11 @@ function showWeeks() {
   setScreen("weeks");
   const zone = isValidZone(state.birthZone) ? state.birthZone : detectZone();
   const bornMs = birthInstantMs(state.birth, zone);
-  const { lived, total } = lifeWeeks(Date.now() - bornMs, state.expectancy);
+  const expectancy = effectiveExpectancy(
+    state,
+    ageYearsFrom(bornMs, Date.now()),
+  );
+  const { lived, total } = lifeWeeks(Date.now() - bornMs, expectancy);
   renderWeeks(
     app,
     { back: showCounter, openSettings: showSettings },
@@ -312,7 +340,7 @@ function showWeeks() {
       born: formatBorn(state.birth),
       lived,
       total,
-      expectancy: clampExpectancy(state.expectancy),
+      expectancy,
     },
   );
 }
@@ -341,6 +369,18 @@ function showSettings() {
       setExpectancy(value) {
         state.expectancy = clampExpectancy(value);
         save(state);
+      },
+      setExpectancySource(value) {
+        state.expectancySource = value === "custom" ? "custom" : "estimate";
+        save(state);
+        // Re-render so the manual Years input swaps with the read-only estimate.
+        showSettings();
+      },
+      setSex(value) {
+        state.sex = value === "male" || value === "female" ? value : null;
+        save(state);
+        // Re-render so the estimate line reflects the new sex immediately.
+        showSettings();
       },
       resetColors() {
         state.theme = null;
@@ -414,11 +454,28 @@ function showSettings() {
     {
       theme: state.theme,
       expectancy: clampExpectancy(state.expectancy),
+      expectancySource:
+        state.expectancySource === "custom" ? "custom" : "estimate",
+      sex: state.sex === "male" || state.sex === "female" ? state.sex : null,
+      estimate: settingsEstimate(),
       typeface: state.typeface,
       reflection: state.reflection,
       birthZone: state.birthZone,
     },
   );
+}
+
+// The actuarial estimate to preview in Settings, for the user's current age and
+// sex at birth — independent of whichever source is active, so the "Estimate"
+// option can always show the number it would apply. Null when there's no
+// birthday yet to derive an age from.
+function settingsEstimate() {
+  const zone = isValidZone(state.birthZone) ? state.birthZone : detectZone();
+  const bornMs = birthInstantMs(state.birth, zone);
+  const ageYears = ageYearsFrom(bornMs, Date.now());
+  return Number.isFinite(ageYears)
+    ? estimateExpectancy(ageYears, state.sex)
+    : null;
 }
 
 let ambientTimer = null;

--- a/src/tab.js
+++ b/src/tab.js
@@ -22,8 +22,10 @@ import {
 import {
   birthInstantMs,
   calendarAge,
+  countdownParts,
   detectZone,
   isValidZone,
+  nextBirthdayInstantMs,
   parseBirthParts,
 } from "./time.js";
 import { estimateExpectancy } from "./lifetable.js";
@@ -36,6 +38,7 @@ const WEEK_MS = 7 * DAY_MS;
 const LABELS = {
   years: "Age",
   calendar: "Calendar age",
+  birthday: "Next birthday",
   days: "Days lived",
   weeks: "Weeks lived",
   yearsLeft: "Years left",
@@ -114,6 +117,16 @@ export function reflectionLine(bornMs, nowMs, expectancy) {
   return `${lived} years behind you \u00b7 ${ahead} ahead, if the tables hold.`;
 }
 
+function birthdayAria({ days, hours, minutes, seconds }) {
+  const unit = (value, name) => `${value} ${name}${value === 1 ? "" : "s"}`;
+  return [
+    unit(days, "day"),
+    unit(hours, "hour"),
+    unit(minutes, "minute"),
+    unit(seconds, "second"),
+  ].join(", ");
+}
+
 // Fold an imported settings blob onto the current state, copying ONLY known keys
 // and sanitising each so a hand-edited or foreign file can't inject junk. Unknown
 // keys are ignored; a key the import omits keeps its current value. Pure.
@@ -164,6 +177,7 @@ function showCounter() {
   // The same effective zone drives the calendar-age breakdown below.
   const zone = isValidZone(state.birthZone) ? state.birthZone : detectZone();
   const bornMs = birthInstantMs(state.birth, zone);
+  let birthdayTarget = nextBirthdayInstantMs(state.birth, Date.now(), zone);
   // Resolve expectancy for the attained age: a custom number is honoured
   // verbatim, otherwise it's an actuarial estimate that legitimately rises a
   // little as the user ages (recomputed here, once per counter show).
@@ -191,13 +205,15 @@ function showCounter() {
   let lastPct = null;
   let lastFrac = -1;
   let lastCal = null;
+  let lastBirthday = null;
 
   function layout() {
     els.label.textContent = LABELS[mode];
-    if (mode === "calendar") {
+    els.count.classList.toggle("birthday-count", mode === "birthday");
+    if (mode === "calendar" || mode === "birthday") {
       intEl = null;
       fracEl = null;
-      // The y/m/d spans are (re)built in tick() whenever the value changes.
+      // Compound spans are (re)built in tick() only when their value changes.
       els.count.replaceChildren();
     } else {
       intEl = el("span", { class: "int" }, "0");
@@ -215,6 +231,7 @@ function showCounter() {
     }
     lastInt = null;
     lastCal = null;
+    lastBirthday = null;
   }
 
   function cycle() {
@@ -280,6 +297,40 @@ function showCounter() {
         );
         lastCal = key;
         updateAria(`${y} years ${m} months ${d} days`);
+      }
+    } else if (mode === "birthday") {
+      if (birthdayTarget <= now) {
+        birthdayTarget = nextBirthdayInstantMs(state.birth, now, zone);
+      }
+      const parts = countdownParts(birthdayTarget - now);
+      const key = `${parts.days}|${parts.hours}|${parts.minutes}|${parts.seconds}`;
+      // The 100ms ticker may run ten times per displayed second; keep the same
+      // nodes until the rounded-up countdown actually changes.
+      if (key !== lastBirthday) {
+        els.count.replaceChildren(
+          el("span", { class: "cal-num" }, String(parts.days)),
+          el("span", { class: "cal-unit" }, "d"),
+          el(
+            "span",
+            { class: "cal-num" },
+            String(parts.hours).padStart(2, "0"),
+          ),
+          el("span", { class: "cal-unit" }, "h"),
+          el(
+            "span",
+            { class: "cal-num" },
+            String(parts.minutes).padStart(2, "0"),
+          ),
+          el("span", { class: "cal-unit" }, "m"),
+          el(
+            "span",
+            { class: "cal-num" },
+            String(parts.seconds).padStart(2, "0"),
+          ),
+          el("span", { class: "cal-unit" }, "s"),
+        );
+        lastBirthday = key;
+        updateAria(`in ${birthdayAria(parts)}`);
       }
     } else {
       let value;

--- a/src/time.js
+++ b/src/time.js
@@ -174,7 +174,7 @@ export function parseBirthParts(birth) {
   const hour = m[4] === undefined ? 0 : +m[4];
   const minute = m[5] === undefined ? 0 : +m[5];
   if (month < 1 || month > 12) return null;
-  if (day < 1 || day > 31) return null;
+  if (day < 1 || day > daysInMonth(year, month)) return null;
   if (hour > 23 || minute > 59) return null;
   return { year, month, day, hour, minute };
 }
@@ -190,6 +190,10 @@ export function isValidZone(zone) {
   }
 }
 
+function resolvedZone(timeZone) {
+  return isValidZone(timeZone) ? timeZone : detectZone();
+}
+
 /**
  * Absolute birth instant (ms) for a stored birth string, interpreted in
  * `timeZone`. Falls back to the detected zone if `timeZone` is missing or
@@ -199,8 +203,58 @@ export function isValidZone(zone) {
 export function birthInstantMs(birth, timeZone) {
   const p = parseBirthParts(birth);
   if (!p) return NaN;
-  const zone = isValidZone(timeZone) ? timeZone : detectZone();
+  const zone = resolvedZone(timeZone);
   return zonedWallClockToUtcMs(p.year, p.month, p.day, p.hour, p.minute, zone);
+}
+
+/**
+ * Absolute instant of the next birthday after `nowMs`, observed in the stored
+ * birth zone at the original wall-clock time. A 29 February birth is observed
+ * on 28 February in non-leap years: clamping to the target month's final day
+ * also guarantees the converter never receives an invalid calendar date.
+ * Returns NaN for malformed birth data or a non-finite current instant.
+ * @param {unknown} birth Stored wall-clock birth string.
+ * @param {number} nowMs Absolute current instant (ms since epoch).
+ * @param {string} timeZone IANA birthplace zone id.
+ * @returns {number}
+ */
+export function nextBirthdayInstantMs(birth, nowMs, timeZone) {
+  const p = parseBirthParts(birth);
+  if (!p || !Number.isFinite(nowMs)) return NaN;
+
+  const zone = resolvedZone(timeZone);
+  const currentYear = zonedParts(nowMs, zone).year;
+  const inYear = (year) =>
+    zonedWallClockToUtcMs(
+      year,
+      p.month,
+      Math.min(p.day, daysInMonth(year, p.month)),
+      p.hour,
+      p.minute,
+      zone,
+    );
+
+  const thisYear = inYear(currentYear);
+  return thisYear > nowMs ? thisYear : inYear(currentYear + 1);
+}
+
+/**
+ * Break a remaining duration into display-ready whole countdown units. Rounding
+ * up to the next second prevents an all-zero reading before the target instant.
+ * @param {number} remainingMs
+ * @returns {{days:number,hours:number,minutes:number,seconds:number}}
+ */
+export function countdownParts(remainingMs) {
+  let seconds = Number.isFinite(remainingMs)
+    ? Math.max(0, Math.ceil(remainingMs / 1000))
+    : 0;
+  const days = Math.floor(seconds / 86400);
+  seconds %= 86400;
+  const hours = Math.floor(seconds / 3600);
+  seconds %= 3600;
+  const minutes = Math.floor(seconds / 60);
+  seconds %= 60;
+  return { days, hours, minutes, seconds };
 }
 
 /** The device's current IANA zone (e.g. "Asia/Tokyo"), or "UTC" if unknown. */

--- a/src/views.js
+++ b/src/views.js
@@ -76,6 +76,25 @@ function gearIcon() {
   );
 }
 
+// Sex-at-birth choices, shared by setup and settings. The empty value is the
+// privacy-respecting default and maps to `null` (no sex shared) at the boundary.
+const SEX_OPTIONS = [
+  ["", "Prefer not to say"],
+  ["female", "Female"],
+  ["male", "Male"],
+];
+
+/** A sex-at-birth <select>, pre-selecting `current` ("male"/"female"/null). */
+function sexSelect(id, current) {
+  const select = el(
+    "select",
+    { id },
+    SEX_OPTIONS.map(([value, label]) => el("option", { value }, label)),
+  );
+  select.value = current === "male" || current === "female" ? current : "";
+  return select;
+}
+
 /** Today as YYYY-MM-DD in local time, used to cap the birth-date field. */
 function todayISO() {
   const now = new Date();
@@ -90,8 +109,8 @@ function splitBirth(value) {
   return [date, time.slice(0, 5)];
 }
 
-/** Birthday entry screen. `current`/`savedZone` pre-fill the fields when editing. */
-export function renderSetup(app, { start }, current, savedZone) {
+/** Birthday entry screen. `current`/`savedZone`/`savedSex` pre-fill when editing. */
+export function renderSetup(app, { start }, current, savedZone, savedSex) {
   const dateEl = el("input", {
     type: "date",
     id: "birth-date",
@@ -115,6 +134,7 @@ export function renderSetup(app, { start }, current, savedZone) {
     ),
   );
   zoneEl.value = selectedZone;
+  const sexEl = sexSelect("birth-sex", savedSex);
   const startBtn = el("button", { id: "start" }, "Start");
   const errorEl = el("p", {
     class: "field-error",
@@ -149,6 +169,15 @@ export function renderSetup(app, { start }, current, savedZone) {
         "Defaults to your current time zone. Set it to where you were born so your age stays exact if you move.",
       ),
     ]),
+    el("div", { class: "setup-field" }, [
+      el("label", { class: "setup-label", for: "birth-sex" }, "Sex at birth"),
+      sexEl,
+      el(
+        "p",
+        { class: "hint" },
+        "Optional — sharpens the life-expectancy estimate.",
+      ),
+    ]),
     el("footer", {}, [startBtn]),
   ]);
   app.replaceChildren(form);
@@ -172,7 +201,7 @@ export function renderSetup(app, { start }, current, savedZone) {
       return;
     }
     errorEl.hidden = true;
-    start(birth, zoneEl.value);
+    start(birth, zoneEl.value, sexEl.value || null);
   }
   form.addEventListener("submit", (event) => {
     event.preventDefault();
@@ -183,7 +212,7 @@ export function renderSetup(app, { start }, current, savedZone) {
       errorEl.hidden = true;
     }),
   );
-  [dateEl, timeEl, zoneEl].forEach((input) =>
+  [dateEl, timeEl, zoneEl, sexEl].forEach((input) =>
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
         event.preventDefault();
@@ -275,7 +304,16 @@ export function renderCounter(
 export function renderSettings(
   app,
   actions,
-  { theme, expectancy, typeface, reflection, birthZone },
+  {
+    theme,
+    expectancy,
+    expectancySource,
+    sex,
+    estimate,
+    typeface,
+    reflection,
+    birthZone,
+  },
 ) {
   const colorInputs = {};
   const notes = {};
@@ -329,6 +367,53 @@ export function renderSettings(
     step: "1",
     value: expectancy,
   });
+
+  // Life expectancy: choose between an age-based actuarial estimate and a manual
+  // number. In "estimate" mode the manual input is hidden and a read-only line
+  // previews the figure in force; "custom" restores the editable Years input.
+  const useEstimate = expectancySource !== "custom";
+  const sourceButtons = [
+    ["estimate", "Estimate"],
+    ["custom", "Custom"],
+  ].map(([value, text]) => {
+    const btn = el(
+      "button",
+      {
+        type: "button",
+        "data-source": value,
+        "aria-pressed": String(useEstimate === (value === "estimate")),
+      },
+      text,
+    );
+    btn.addEventListener("click", () => actions.setExpectancySource(value));
+    return btn;
+  });
+  const sourceSegment = el(
+    "div",
+    {
+      class: "segment",
+      role: "group",
+      "aria-labelledby": "expectancy-source-label",
+    },
+    sourceButtons,
+  );
+  const estimateLine = el(
+    "p",
+    { class: "settings-hint", id: "expectancy-estimate" },
+    estimate != null
+      ? `\u2248 ${estimate} years \u2014 actuarial estimate for your age.`
+      : "Add your birthday to see an actuarial estimate.",
+  );
+  const customRow = el("div", { class: "row" }, [
+    el("label", { for: "expectancy" }, "Years"),
+    expectancyInput,
+  ]);
+  const sexEl = sexSelect("settings-sex", sex);
+  sexEl.addEventListener("change", () => actions.setSex(sexEl.value || null));
+  const sexRow = el("div", { class: "row" }, [
+    el("label", { for: "settings-sex" }, "Sex at birth"),
+    sexEl,
+  ]);
 
   // Display: numeral typeface (segmented control) + reflection-line toggle.
   const numeralsLabel = el("label", { id: "numerals-label" }, "Numerals");
@@ -424,9 +509,16 @@ export function renderSettings(
     ]),
     el("p", { class: "settings-label" }, "Life expectancy"),
     el("div", { class: "row" }, [
-      el("label", { for: "expectancy" }, "Years"),
-      expectancyInput,
+      el("label", { id: "expectancy-source-label" }, "Source"),
+      sourceSegment,
     ]),
+    useEstimate ? estimateLine : customRow,
+    sexRow,
+    el(
+      "p",
+      { class: "settings-hint" },
+      "Optional — sharpens the life-expectancy estimate.",
+    ),
     el("p", { class: "settings-label" }, "Time zone"),
     el("div", { class: "setup-field" }, [
       el("label", { class: "setup-label", for: "settings-zone" }, "Born in"),

--- a/test/lifetable.test.js
+++ b/test/lifetable.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { MALE, FEMALE, UNISEX, estimateExpectancy } from "../src/lifetable.js";
+
+const AGES = Array.from({ length: 120 }, (_, x) => x);
+
+describe("life table data", () => {
+  it("covers integer ages 0..119 for both sexes", () => {
+    expect(MALE.length).toBe(120);
+    expect(FEMALE.length).toBe(120);
+    expect(UNISEX.length).toBe(120);
+  });
+
+  it("matches the SSA source spot values (Period Life Table, 2023)", () => {
+    expect(MALE[0]).toBeCloseTo(75.79, 2);
+    expect(MALE[65]).toBeCloseTo(18.12, 2);
+    expect(MALE[100]).toBeCloseTo(2.04, 2);
+    expect(FEMALE[0]).toBeCloseTo(81.06, 2);
+    expect(FEMALE[65]).toBeCloseTo(20.66, 2);
+    expect(FEMALE[100]).toBeCloseTo(2.23, 2);
+  });
+
+  it("derives UNISEX as the simple average of MALE and FEMALE", () => {
+    for (const x of AGES) {
+      expect(UNISEX[x]).toBeCloseTo((MALE[x] + FEMALE[x]) / 2, 10);
+    }
+  });
+
+  it("has a non-increasing e(x) with age (remaining life shrinks)", () => {
+    for (const table of [MALE, FEMALE, UNISEX]) {
+      for (let x = 1; x < table.length; x++) {
+        expect(table[x]).toBeLessThanOrEqual(table[x - 1] + 1e-9);
+      }
+    }
+  });
+
+  it("keeps female e(x) at or above male e(x) at every age", () => {
+    for (const x of AGES) {
+      expect(FEMALE[x]).toBeGreaterThanOrEqual(MALE[x]);
+    }
+  });
+});
+
+describe("estimateExpectancy", () => {
+  it("returns a plausible at-birth expectancy for each sex", () => {
+    // Recent SSA period tables: e(0) male ~73-76, female ~79-82.
+    expect(estimateExpectancy(0, "male")).toBeGreaterThanOrEqual(73);
+    expect(estimateExpectancy(0, "male")).toBeLessThanOrEqual(76);
+    expect(estimateExpectancy(0, "female")).toBeGreaterThanOrEqual(79);
+    expect(estimateExpectancy(0, "female")).toBeLessThanOrEqual(82);
+  });
+
+  it("always returns a whole number", () => {
+    for (const x of [0, 12.4, 40, 65.5, 90, 119]) {
+      for (const sex of ["male", "female", null]) {
+        expect(Number.isInteger(estimateExpectancy(x, sex))).toBe(true);
+      }
+    }
+  });
+
+  it("never returns less than the attained age", () => {
+    for (const x of AGES) {
+      expect(estimateExpectancy(x, "male")).toBeGreaterThanOrEqual(x);
+      expect(estimateExpectancy(x, "female")).toBeGreaterThanOrEqual(x);
+      expect(estimateExpectancy(x, null)).toBeGreaterThanOrEqual(x);
+    }
+  });
+
+  it("has a total expected age that rises with attained age", () => {
+    for (const sex of ["male", "female", null]) {
+      for (let x = 1; x < 120; x++) {
+        expect(estimateExpectancy(x, sex)).toBeGreaterThanOrEqual(
+          estimateExpectancy(x - 1, sex),
+        );
+      }
+    }
+  });
+
+  it("estimates a higher total for older users than the flat at-birth figure", () => {
+    // Conditioning on survival: a 70-year-old outlives the at-birth average.
+    expect(estimateExpectancy(70, "male")).toBeGreaterThan(
+      estimateExpectancy(0, "male"),
+    );
+  });
+
+  it("orders the sexes: female >= unisex >= male at a given age", () => {
+    for (const x of [0, 25, 50, 70, 90]) {
+      const male = estimateExpectancy(x, "male");
+      const female = estimateExpectancy(x, "female");
+      const unisex = estimateExpectancy(x, null);
+      expect(female).toBeGreaterThanOrEqual(unisex);
+      expect(unisex).toBeGreaterThanOrEqual(male);
+    }
+  });
+
+  it("treats an unknown sex as unisex", () => {
+    expect(estimateExpectancy(40, undefined)).toBe(
+      estimateExpectancy(40, null),
+    );
+    expect(estimateExpectancy(40, "other")).toBe(estimateExpectancy(40, null));
+  });
+
+  it("interpolates e(x) smoothly between integer ages", () => {
+    // The half-year point sits between the two bracketing integer totals.
+    const lo = estimateExpectancy(40, "male");
+    const hi = estimateExpectancy(41, "male");
+    const mid = estimateExpectancy(40.5, "male");
+    expect(mid).toBeGreaterThanOrEqual(Math.min(lo, hi));
+    expect(mid).toBeLessThanOrEqual(Math.max(lo, hi));
+  });
+
+  it("clamps the attained age to the table bounds", () => {
+    // Below 0 and above the last index resolve to the endpoint estimates.
+    expect(estimateExpectancy(-10, "male")).toBe(estimateExpectancy(0, "male"));
+    expect(estimateExpectancy(500, "male")).toBe(
+      estimateExpectancy(119, "male"),
+    );
+  });
+
+  it("keeps the result inside the app's [1, 150] band", () => {
+    for (const x of [-100, 0, 60, 119, 1000]) {
+      const value = estimateExpectancy(x, "female");
+      expect(value).toBeGreaterThanOrEqual(1);
+      expect(value).toBeLessThanOrEqual(150);
+    }
+  });
+
+  it("falls back to a sane figure for non-finite ages", () => {
+    expect(estimateExpectancy(NaN, null)).toBe(estimateExpectancy(0, null));
+    expect(estimateExpectancy(Infinity, "male")).toBeLessThanOrEqual(150);
+  });
+});

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -12,6 +12,8 @@ import {
   bestOnColor,
   applyTheme,
   applyTypeface,
+  clampExpectancy,
+  effectiveExpectancy,
 } from "../src/store.js";
 
 // Independent WCAG contrast implementation, used to verify the PRESETS meet the
@@ -217,6 +219,8 @@ describe("save / load with the localStorage fallback", () => {
       birthZone: null,
       theme: null,
       expectancy: 80,
+      expectancySource: "estimate",
+      sex: null,
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -230,6 +234,8 @@ describe("save / load with the localStorage fallback", () => {
       birthZone: "America/New_York",
       theme: { bg: "#111111", label: "#aaa", count: "#fff", accent: "#f00" },
       expectancy: 70,
+      expectancySource: "custom",
+      sex: "female",
       mode: "days",
       typeface: "mono",
       reflection: true,
@@ -246,6 +252,10 @@ describe("save / load with the localStorage fallback", () => {
       birthZone: "Asia/Tokyo",
       theme: null,
       expectancy: 80,
+      // A record already on disk that predates the estimate feature is pinned to
+      // "custom" so its flat number never silently changes on update.
+      expectancySource: "custom",
+      sex: null,
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -289,6 +299,8 @@ describe("save / load with the localStorage fallback", () => {
       birthZone: null,
       theme: null,
       expectancy: 80,
+      expectancySource: "estimate",
+      sex: null,
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -312,10 +324,99 @@ describe("save / load with the localStorage fallback", () => {
       birthZone: null,
       theme: null,
       expectancy: 80,
+      expectancySource: "estimate",
+      sex: null,
       mode: "years",
       typeface: "system",
       reflection: false,
     });
+  });
+});
+
+describe("expectancy-source migration", () => {
+  it("defaults a brand-new install to the actuarial estimate source", async () => {
+    const result = await load();
+    expect(result.expectancySource).toBe("estimate");
+    expect(result.sex).toBe(null);
+  });
+
+  it("pins a pre-existing record without a source to custom", async () => {
+    // A record already on disk (pre-feature) keeps its flat number verbatim.
+    await save({ birth: "1980-01-01T00:00", birthZone: "UTC", expectancy: 66 });
+    const result = await load();
+    expect(result.expectancySource).toBe("custom");
+    expect(result.expectancy).toBe(66);
+    expect(result.sex).toBe(null);
+  });
+
+  it("preserves an explicit estimate source on an existing record", async () => {
+    await save({
+      birth: "1980-01-01T00:00",
+      birthZone: "UTC",
+      expectancySource: "estimate",
+      sex: "female",
+    });
+    const result = await load();
+    expect(result.expectancySource).toBe("estimate");
+    expect(result.sex).toBe("female");
+  });
+
+  it("migrates the legacy dob record to a custom source", async () => {
+    localStorage.setItem("dob", "1970-01-01");
+    const result = await load();
+    expect(result.expectancySource).toBe("custom");
+    expect(result.sex).toBe(null);
+  });
+
+  it("persists the migration so it stays stable on the next load", async () => {
+    await save({ birth: "1980-01-01T00:00", birthZone: "UTC", expectancy: 72 });
+    await load();
+    const persisted = JSON.parse(localStorage.getItem("mortality"));
+    expect(persisted.expectancySource).toBe("custom");
+    expect(persisted.sex).toBe(null);
+  });
+});
+
+describe("effectiveExpectancy", () => {
+  it("honours a custom number verbatim, clamped to range", () => {
+    expect(
+      effectiveExpectancy({ expectancySource: "custom", expectancy: 70 }, 40),
+    ).toBe(70);
+    expect(
+      effectiveExpectancy({ expectancySource: "custom", expectancy: 999 }, 40),
+    ).toBe(150);
+  });
+
+  it("derives an actuarial estimate from age and sex when set to estimate", () => {
+    const male = effectiveExpectancy(
+      { expectancySource: "estimate", sex: "male", expectancy: 80 },
+      70,
+    );
+    const female = effectiveExpectancy(
+      { expectancySource: "estimate", sex: "female", expectancy: 80 },
+      70,
+    );
+    expect(Number.isInteger(male)).toBe(true);
+    expect(male).toBeGreaterThanOrEqual(70); // never below current age
+    expect(female).toBeGreaterThanOrEqual(male); // female >= male
+  });
+
+  it("falls back to the clamped custom value when the age is unavailable", () => {
+    expect(
+      effectiveExpectancy(
+        { expectancySource: "estimate", expectancy: 66, sex: "male" },
+        NaN,
+      ),
+    ).toBe(66);
+  });
+});
+
+describe("clampExpectancy", () => {
+  it("clamps into the supported [1, 150] whole-year band", () => {
+    expect(clampExpectancy(80)).toBe(80);
+    expect(clampExpectancy(0)).toBe(1);
+    expect(clampExpectancy(999)).toBe(150);
+    expect(clampExpectancy("abc")).toBe(80);
   });
 });
 
@@ -364,6 +465,8 @@ describe("save / load against extension storage", () => {
       birthZone: "Europe/London",
       theme: null,
       expectancy: 95,
+      expectancySource: "custom",
+      sex: null,
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -402,6 +505,8 @@ describe("save / load against extension storage", () => {
       birthZone: null,
       theme: null,
       expectancy: 80,
+      expectancySource: "estimate",
+      sex: null,
       mode: "years",
       typeface: "system",
       reflection: false,

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -43,6 +43,7 @@ describe("constants", () => {
     expect(MODES).toEqual([
       "years",
       "calendar",
+      "birthday",
       "days",
       "weeks",
       "yearsLeft",

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -3,6 +3,7 @@
 // via the localStorage fallback, and fake timers so the age ticker never loops.
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { PRESETS } from "../src/store.js";
+import { estimateExpectancy } from "../src/lifetable.js";
 
 const YEAR_MS = 31556900000; // must match tab.js
 const DAY_MS = 86400000;
@@ -87,6 +88,18 @@ describe("setup flow", () => {
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
     expect(document.body.className).toBe("screen-counter");
     expect(stored().birth).toBe("1990-06-15T00:00");
+  });
+
+  it("persists the optional sex chosen at setup", async () => {
+    await boot();
+    document.querySelector("#birth-date").value = "1990-06-15";
+    document.querySelector("#birth-sex").value = "female";
+    document
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(stored().sex).toBe("female");
+    // A brand-new setup leaves the actuarial estimate as the active source.
+    expect(stored().expectancySource).toBe("estimate");
   });
 });
 
@@ -307,6 +320,91 @@ describe("settings routing and edits", () => {
     document.querySelector("#gear").click();
     document.querySelector("#reset-birthday").click();
     expect(document.body.className).toBe("screen-setup");
+  });
+});
+
+describe("settings: life-expectancy source and sex", () => {
+  const bornMs = new Date("2000-01-01T00:00").getTime();
+  const ageYears = (from) => (from - bornMs) / YEAR_MS;
+
+  it("uses the actuarial estimate as the counter denominator in estimate mode", async () => {
+    seed({
+      birth: "2000-01-01T00:00",
+      expectancySource: "estimate",
+      sex: "male",
+      mode: "years",
+    });
+    await boot();
+    const expected = estimateExpectancy(ageYears(Date.now()), "male");
+    const caption = document.querySelector("#pct").textContent;
+    const shown = Number(caption.match(/of (\d+) yrs lived/)[1]);
+    expect(shown).toBe(expected);
+    // A 20-year-old's conditional expectancy differs from the flat at-birth 80.
+    expect(shown).not.toBe(80);
+  });
+
+  it("reflects the chosen sex in the estimate denominator", async () => {
+    seed({
+      birth: "2000-01-01T00:00",
+      expectancySource: "estimate",
+      sex: "female",
+      mode: "years",
+    });
+    await boot();
+    const expected = estimateExpectancy(ageYears(Date.now()), "female");
+    const shown = Number(
+      document.querySelector("#pct").textContent.match(/of (\d+) yrs lived/)[1],
+    );
+    expect(shown).toBe(expected);
+  });
+
+  it("switches source to estimate from settings, swapping the manual input out", async () => {
+    seed({
+      birth: "2000-01-01T00:00",
+      expectancySource: "custom",
+      expectancy: 80,
+    });
+    await boot();
+    document.querySelector("#gear").click();
+    // Custom mode shows the editable Years input.
+    expect(document.querySelector("#expectancy")).not.toBeNull();
+
+    document.querySelector('[data-source="estimate"]').click();
+    expect(stored().expectancySource).toBe("estimate");
+    // Estimate mode hides the manual input and previews the figure instead.
+    expect(document.querySelector("#expectancy")).toBeNull();
+    expect(document.querySelector("#expectancy-estimate")).not.toBeNull();
+  });
+
+  it("switches back to custom, restoring the editable input", async () => {
+    seed({
+      birth: "2000-01-01T00:00",
+      expectancySource: "estimate",
+      sex: "male",
+    });
+    await boot();
+    document.querySelector("#gear").click();
+    expect(document.querySelector("#expectancy")).toBeNull();
+
+    document.querySelector('[data-source="custom"]').click();
+    expect(stored().expectancySource).toBe("custom");
+    expect(document.querySelector("#expectancy")).not.toBeNull();
+  });
+
+  it("changes the sex from settings and persists it", async () => {
+    seed({
+      birth: "2000-01-01T00:00",
+      expectancySource: "estimate",
+      sex: null,
+    });
+    await boot();
+    document.querySelector("#gear").click();
+    const sex = document.querySelector("#settings-sex");
+    sex.value = "male";
+    sex.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(stored().sex).toBe("male");
+    // The estimate line re-renders for the new sex.
+    expect(document.querySelector("#expectancy-estimate")).not.toBeNull();
   });
 });
 

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -108,14 +108,21 @@ describe("counter interactions", () => {
     seed({ birth: "2000-01-01T00:00", mode: "years" });
     await boot();
 
-    // years -> calendar (the new mode inserted after years).
+    // years -> calendar.
     document.querySelector("#count").click();
     expect(document.querySelector("#unit-label").textContent).toBe(
       "Calendar age",
     );
     expect(stored().mode).toBe("calendar");
 
-    // calendar -> days.
+    // calendar -> birthday (inserted immediately after calendar).
+    document.querySelector("#count").click();
+    expect(document.querySelector("#unit-label").textContent).toBe(
+      "Next birthday",
+    );
+    expect(stored().mode).toBe("birthday");
+
+    // birthday -> days.
     document.querySelector("#count").click();
     expect(document.querySelector("#unit-label").textContent).toBe(
       "Days lived",
@@ -248,6 +255,90 @@ describe("counter interactions", () => {
     expect(units).toEqual(["yr", "mo", "d"]);
     expect(document.querySelector("#count").getAttribute("aria-label")).toBe(
       "Calendar age 20 years 0 months 0 days. Activate to change units.",
+    );
+  });
+
+  it("renders the next birthday in the birth zone with a readable label", async () => {
+    vi.setSystemTime(new Date("2024-03-14T00:00:00Z"));
+    seed({
+      birth: "2000-03-15T09:30",
+      birthZone: "Asia/Tokyo",
+      mode: "birthday",
+    });
+    await boot();
+
+    expect(document.querySelector("#unit-label").textContent).toBe(
+      "Next birthday",
+    );
+    expect(
+      [...document.querySelectorAll("#count .cal-num")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(["1", "00", "30", "00"]);
+    expect(
+      [...document.querySelectorAll("#count .cal-unit")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(["d", "h", "m", "s"]);
+    expect(document.querySelector("#count").getAttribute("aria-label")).toBe(
+      "Next birthday in 1 day, 0 hours, 30 minutes, 0 seconds. Activate to change units.",
+    );
+  });
+
+  it("decrements live without rebuilding inside the displayed second", async () => {
+    vi.setSystemTime(new Date("2019-12-31T23:59:54.100Z"));
+    seed({
+      birth: "2000-01-01T00:00",
+      birthZone: "UTC",
+      mode: "birthday",
+    });
+    await boot();
+
+    const firstDayNode = document.querySelector("#count .cal-num");
+    expect(
+      [...document.querySelectorAll("#count .cal-num")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(["0", "00", "00", "06"]);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(document.querySelector("#count .cal-num")).toBe(firstDayNode);
+
+    await vi.advanceTimersByTimeAsync(900);
+    expect(document.querySelector("#count .cal-num")).not.toBe(firstDayNode);
+    expect(
+      [...document.querySelectorAll("#count .cal-num")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(["0", "00", "00", "05"]);
+  });
+
+  it("rolls directly to the following birthday at the target instant", async () => {
+    vi.setSystemTime(new Date("2019-12-31T23:59:59.500Z"));
+    seed({
+      birth: "2000-01-01T00:00",
+      birthZone: "UTC",
+      mode: "birthday",
+    });
+    await boot();
+
+    expect(
+      [...document.querySelectorAll("#count .cal-num")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(["0", "00", "00", "01"]);
+    expect(document.querySelector("#count").getAttribute("aria-label")).toBe(
+      "Next birthday in 0 days, 0 hours, 0 minutes, 1 second. Activate to change units.",
+    );
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(
+      [...document.querySelectorAll("#count .cal-num")].map(
+        (node) => node.textContent,
+      ),
+    ).toEqual(["366", "00", "00", "00"]);
+    expect(document.querySelector("#count").getAttribute("aria-label")).toBe(
+      "Next birthday in 366 days, 0 hours, 0 minutes, 0 seconds. Activate to change units.",
     );
   });
 });

--- a/test/tab.test.js
+++ b/test/tab.test.js
@@ -116,6 +116,8 @@ describe("mergeImported", () => {
     birthZone: "Asia/Tokyo",
     theme: null,
     expectancy: 80,
+    expectancySource: "estimate",
+    sex: null,
     mode: "years",
     typeface: "system",
     reflection: false,
@@ -142,6 +144,27 @@ describe("mergeImported", () => {
     expect(mergeImported(current, { expectancy: 999 }).expectancy).toBe(150);
     expect(mergeImported(current, { expectancy: 0 }).expectancy).toBe(1);
     expect(mergeImported(current, { expectancy: "62" }).expectancy).toBe(62);
+  });
+
+  it("accepts a valid sex and coerces anything else to null", () => {
+    expect(mergeImported(current, { sex: "male" }).sex).toBe("male");
+    expect(mergeImported(current, { sex: "female" }).sex).toBe("female");
+    expect(mergeImported(current, { sex: "other" }).sex).toBeNull();
+    expect(mergeImported(current, { sex: 123 }).sex).toBeNull();
+    expect(mergeImported(current, { sex: null }).sex).toBeNull();
+  });
+
+  it("accepts a valid expectancy source and ignores an invalid one", () => {
+    expect(
+      mergeImported(current, { expectancySource: "custom" }).expectancySource,
+    ).toBe("custom");
+    expect(
+      mergeImported(current, { expectancySource: "estimate" }).expectancySource,
+    ).toBe("estimate");
+    // An unrecognised value keeps the current source rather than corrupting it.
+    expect(
+      mergeImported(current, { expectancySource: "banana" }).expectancySource,
+    ).toBe(current.expectancySource);
   });
 
   it("falls back to the system typeface for an unknown value", () => {

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -6,6 +6,8 @@ import {
   calendarAge,
   parseBirthParts,
   birthInstantMs,
+  nextBirthdayInstantMs,
+  countdownParts,
   isValidZone,
   detectZone,
   listTimeZones,
@@ -148,7 +150,14 @@ describe("parseBirthParts", () => {
   });
 
   it("returns null for malformed or out-of-range values", () => {
-    for (const value of ["", "not-a-date", "1990-13-01", "1990-05-32", null]) {
+    for (const value of [
+      "",
+      "not-a-date",
+      "1990-13-01",
+      "1990-05-32",
+      "1990-02-30",
+      null,
+    ]) {
       expect(parseBirthParts(value)).toBeNull();
     }
   });
@@ -170,6 +179,115 @@ describe("birthInstantMs", () => {
     expect(birthInstantMs("2000-01-01T00:00", "Not/AZone")).toBe(
       birthInstantMs("2000-01-01T00:00", detected),
     );
+  });
+});
+
+describe("nextBirthdayInstantMs", () => {
+  const birth = "1990-03-15T09:30";
+
+  it("targets this year's birthday when it is still ahead in the birth zone", () => {
+    const now = Date.parse("2024-03-14T00:00:00Z");
+    expect(nextBirthdayInstantMs(birth, now, "Asia/Tokyo")).toBe(
+      Date.parse("2024-03-15T09:30:00+09:00"),
+    );
+  });
+
+  it("targets next year's birthday after this year's birth time has passed", () => {
+    const now = Date.parse("2024-03-15T00:31:00Z");
+    expect(nextBirthdayInstantMs(birth, now, "Asia/Tokyo")).toBe(
+      Date.parse("2025-03-15T09:30:00+09:00"),
+    );
+  });
+
+  it("treats the exact birthday instant as reached and advances a year", () => {
+    const now = Date.parse("2024-03-15T09:30:00+09:00");
+    expect(nextBirthdayInstantMs(birth, now, "Asia/Tokyo")).toBe(
+      Date.parse("2025-03-15T09:30:00+09:00"),
+    );
+  });
+
+  it("uses the birth zone's calendar year rather than the viewer's", () => {
+    const now = Date.parse("2024-01-01T01:00:00Z");
+    const newYearBirth = "2000-01-01T00:00";
+
+    // It is already 1 January in Tokyo, but still 31 December in Los Angeles.
+    expect(nextBirthdayInstantMs(newYearBirth, now, "Asia/Tokyo")).toBe(
+      Date.parse("2025-01-01T00:00:00+09:00"),
+    );
+    expect(
+      nextBirthdayInstantMs(newYearBirth, now, "America/Los_Angeles"),
+    ).toBe(Date.parse("2024-01-01T00:00:00-08:00"));
+  });
+
+  it("preserves the birth wall-clock time and target-year DST offset", () => {
+    const now = Date.parse("2024-01-01T00:00:00Z");
+    expect(
+      nextBirthdayInstantMs("1990-07-04T18:45", now, "America/New_York"),
+    ).toBe(Date.parse("2024-07-04T18:45:00-04:00"));
+  });
+
+  it("observes a leap-day birth on 29 February in a leap target year", () => {
+    const now = Date.parse("2024-01-01T00:00:00Z");
+    expect(nextBirthdayInstantMs("2000-02-29T08:15", now, "UTC")).toBe(
+      Date.parse("2024-02-29T08:15:00Z"),
+    );
+  });
+
+  it("observes a leap-day birth on 28 February in a non-leap target year", () => {
+    const now = Date.parse("2023-01-01T00:00:00Z");
+    expect(nextBirthdayInstantMs("2000-02-29T08:15", now, "UTC")).toBe(
+      Date.parse("2023-02-28T08:15:00Z"),
+    );
+  });
+
+  it("returns NaN for malformed birth data", () => {
+    expect(
+      Number.isNaN(
+        nextBirthdayInstantMs("2000-02-30T08:15", Date.now(), "UTC"),
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to the detected zone when the supplied zone is invalid", () => {
+    const now = Date.parse("2024-01-01T00:00:00Z");
+    expect(nextBirthdayInstantMs(birth, now, "Not/AZone")).toBe(
+      nextBirthdayInstantMs(birth, now, detectZone()),
+    );
+  });
+});
+
+describe("countdownParts", () => {
+  it("rounds one remaining millisecond up to one second", () => {
+    expect(countdownParts(1)).toEqual({
+      days: 0,
+      hours: 0,
+      minutes: 0,
+      seconds: 1,
+    });
+  });
+
+  it("clamps zero, negative, and non-finite durations", () => {
+    const zero = { days: 0, hours: 0, minutes: 0, seconds: 0 };
+    expect(countdownParts(0)).toEqual(zero);
+    expect(countdownParts(-1)).toEqual(zero);
+    expect(countdownParts(NaN)).toEqual(zero);
+  });
+
+  it.each([
+    [60000, { days: 0, hours: 0, minutes: 1, seconds: 0 }],
+    [3600000, { days: 0, hours: 1, minutes: 0, seconds: 0 }],
+    [86400000, { days: 1, hours: 0, minutes: 0, seconds: 0 }],
+  ])("splits exact unit boundary %i", (remainingMs, expected) => {
+    expect(countdownParts(remainingMs)).toEqual(expected);
+  });
+
+  it("splits multiple days and rounds a partial second up", () => {
+    expect(countdownParts(2 * 86400000 + 3 * 3600000 + 4 * 60000 + 1)).toEqual({
+      days: 2,
+      hours: 3,
+      minutes: 4,
+      seconds: 1,
+    });
   });
 });
 

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -47,7 +47,7 @@ describe("renderSetup", () => {
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2000-03-04T09:15", zone);
+    expect(start).toHaveBeenCalledWith("2000-03-04T09:15", zone, null);
   });
 
   it("defaults an empty time to midnight", () => {
@@ -58,7 +58,7 @@ describe("renderSetup", () => {
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2010-10-10T00:00", zone);
+    expect(start).toHaveBeenCalledWith("2010-10-10T00:00", zone, null);
   });
 
   it("blocks submission and reports validity when the date is empty", () => {
@@ -79,7 +79,7 @@ describe("renderSetup", () => {
     app.querySelector("#birth-date").value = "1975-12-25";
     const zone = app.querySelector("#birth-zone").value;
     keydown(app.querySelector("#birth-date"), "Enter");
-    expect(start).toHaveBeenCalledWith("1975-12-25T00:00", zone);
+    expect(start).toHaveBeenCalledWith("1975-12-25T00:00", zone, null);
   });
 
   it("renders a birthplace time-zone select defaulting to the device zone", () => {
@@ -130,6 +130,34 @@ describe("renderSetup", () => {
     dateEl.value = "1990-01-01";
     dateEl.dispatchEvent(new Event("input", { bubbles: true }));
     expect(app.querySelector("#birth-error").hidden).toBe(true);
+  });
+
+  it("offers an optional sex-at-birth select defaulting to unspecified", () => {
+    renderSetup(app, { start: vi.fn() }, null);
+    const sex = app.querySelector("#birth-sex");
+    expect(sex).not.toBeNull();
+    expect(sex.tagName).toBe("SELECT");
+    expect(sex.value).toBe("");
+    const label = app.querySelector('label[for="birth-sex"]');
+    expect(label).not.toBeNull();
+    expect(label.textContent).toBe("Sex at birth");
+  });
+
+  it("pre-selects the saved sex when editing", () => {
+    renderSetup(app, { start: vi.fn() }, "1990-05-15T00:00", "UTC", "female");
+    expect(app.querySelector("#birth-sex").value).toBe("female");
+  });
+
+  it("passes the chosen sex through to start", () => {
+    const start = vi.fn();
+    renderSetup(app, { start }, null);
+    app.querySelector("#birth-date").value = "1980-07-08";
+    app.querySelector("#birth-sex").value = "male";
+    const zone = app.querySelector("#birth-zone").value;
+    app
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(start).toHaveBeenCalledWith("1980-07-08T00:00", zone, "male");
   });
 });
 
@@ -197,6 +225,8 @@ describe("renderSettings", () => {
     setColor: vi.fn(),
     applyPreset: vi.fn(),
     setExpectancy: vi.fn(),
+    setExpectancySource: vi.fn(),
+    setSex: vi.fn(),
     resetColors: vi.fn(),
     resetBirthday: vi.fn(),
     closeSettings: vi.fn(),
@@ -210,6 +240,9 @@ describe("renderSettings", () => {
   const data = (over = {}) => ({
     theme: null,
     expectancy: 80,
+    expectancySource: "custom",
+    sex: null,
+    estimate: 84,
     typeface: "system",
     reflection: false,
     birthZone: null,
@@ -249,7 +282,7 @@ describe("renderSettings", () => {
   });
 
   it("shows the current life expectancy", () => {
-    renderSettings(app, actions(), { theme: null, expectancy: 73 });
+    renderSettings(app, actions(), data({ expectancy: 73 }));
     expect(app.querySelector("#expectancy").value).toBe("73");
   });
 
@@ -272,7 +305,7 @@ describe("renderSettings", () => {
 
   it("reports life-expectancy edits", () => {
     const a = actions();
-    renderSettings(app, a, { theme: null, expectancy: 80 });
+    renderSettings(app, a, data());
     const input = app.querySelector("#expectancy");
     input.value = "42";
     input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -371,5 +404,67 @@ describe("renderSettings", () => {
     app.querySelector("#import-data").click();
     expect(a.exportData).toHaveBeenCalledOnce();
     expect(a.importData).toHaveBeenCalledOnce();
+  });
+
+  it("renders the expectancy source segment reflecting the current source", () => {
+    renderSettings(app, actions(), data({ expectancySource: "custom" }));
+    expect(
+      app.querySelector('[data-source="custom"]').getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      app
+        .querySelector('[data-source="estimate"]')
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("shows the editable Years input and no estimate line in custom mode", () => {
+    renderSettings(app, actions(), data({ expectancySource: "custom" }));
+    expect(app.querySelector("#expectancy")).not.toBeNull();
+    expect(app.querySelector("#expectancy-estimate")).toBeNull();
+  });
+
+  it("hides the Years input and previews the estimate in estimate mode", () => {
+    renderSettings(
+      app,
+      actions(),
+      data({ expectancySource: "estimate", estimate: 84 }),
+    );
+    expect(app.querySelector("#expectancy")).toBeNull();
+    const line = app.querySelector("#expectancy-estimate");
+    expect(line).not.toBeNull();
+    expect(line.textContent).toContain("84");
+    expect(line.textContent).toContain("actuarial estimate");
+  });
+
+  it("prompts for a birthday when no estimate is available", () => {
+    renderSettings(
+      app,
+      actions(),
+      data({ expectancySource: "estimate", estimate: null }),
+    );
+    expect(app.querySelector("#expectancy-estimate").textContent).toContain(
+      "Add your birthday",
+    );
+  });
+
+  it("reports source changes when a segment button is clicked", () => {
+    const a = actions();
+    renderSettings(app, a, data({ expectancySource: "custom" }));
+    app.querySelector('[data-source="estimate"]').click();
+    expect(a.setExpectancySource).toHaveBeenCalledWith("estimate");
+  });
+
+  it("preselects the stored sex and reports changes, mapping blank to null", () => {
+    const a = actions();
+    renderSettings(app, a, data({ sex: "female" }));
+    const sex = app.querySelector("#settings-sex");
+    expect(sex.value).toBe("female");
+    sex.value = "male";
+    sex.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(a.setSex).toHaveBeenCalledWith("male");
+    sex.value = "";
+    sex.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(a.setSex).toHaveBeenCalledWith(null);
   });
 });


### PR DESCRIPTION
## Summary
- add the actuarial life-expectancy prerequisite from #55
- add a click-cycled `Next birthday` mode after calendar age
- calculate the target birthday from the stored birthplace time zone and original birth time, including a February 28 observance for leap-day births in non-leap years
- render an efficient, accessible live days/hours/minutes/seconds countdown with clean yearly rollover
- add focused timezone, duration, mode-cycle, live-update, accessibility, and rollover coverage

## Stack note
This branch is rebased on current `main` and preserves #55 as its prerequisite commit. Merging this PR lands both #55 and the next-birthday layer together.

## Validation
- `npm test` (208 tests)
- `npm run format`
- `npm run format:check`
- `node --check src/store.js`
- `node --check src/tab.js`
- `node --check src/time.js`