### PR TITLE
Add a global actuarial life-expectancy baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ A browser extension that replaces your new tab page with a live counter of your 
 - **Multiple units** — switch between age, calendar age, a live next-birthday
   countdown, days or weeks lived, time left, and percent of an expected lifetime
   elapsed.
+- **Actuarial estimate** — conditions expected lifespan on your current age, using an
+  explicitly selected World (UN 2023) or United States (SSA 2023) baseline.
 - **Personalization** — light and dark themes that follow your system, color presets
-  and custom colors, and an adjustable life expectancy.
+  and custom colors, plus a fully custom life expectancy.
 - **Accessible and calm** — WCAG 2.1 AA, a `prefers-reduced-motion` path, and full
   keyboard support.
 

--- a/src/THIRD_PARTY_NOTICES.txt
+++ b/src/THIRD_PARTY_NOTICES.txt
@@ -1,0 +1,31 @@
+Mortality includes data from the following sources:
+
+UNITED NATIONS WORLD POPULATION PROSPECTS 2024
+
+United Nations, Department of Economic and Social Affairs, Population
+Division (2024). World Population Prospects 2024.
+https://population.un.org/wpp/
+
+The embedded World 2023 male, female, and both-sexes
+life-expectancy-at-age (ex) series were extracted from these complete
+life-table CSV files and converted to JavaScript arrays:
+
+https://population.un.org/wpp/assets/Excel%20Files/1_Indicator%20(Standard)/CSV_FILES/WPP2024_Life_Table_Complete_Medium_Male_1950-2023.csv.gz
+https://population.un.org/wpp/assets/Excel%20Files/1_Indicator%20(Standard)/CSV_FILES/WPP2024_Life_Table_Complete_Medium_Female_1950-2023.csv.gz
+https://population.un.org/wpp/assets/Excel%20Files/1_Indicator%20(Standard)/CSV_FILES/WPP2024_Life_Table_Complete_Medium_Both_1950-2023.csv.gz
+
+Licensed under Creative Commons Attribution 3.0 IGO:
+https://creativecommons.org/licenses/by/3.0/igo/
+
+The data may be shared and adapted with attribution. Mortality is not
+endorsed by the United Nations.
+
+
+U.S. SOCIAL SECURITY ADMINISTRATION PERIOD LIFE TABLE 2023
+
+U.S. Social Security Administration, Actuarial Life Table, Period Life
+Table 2023 (as used in the 2026 Trustees Report).
+https://www.ssa.gov/oact/STATS/table4c6.html
+
+This table is a work of the U.S. federal government and is in the public
+domain under 17 U.S.C. Section 105.

--- a/src/lifetable.js
+++ b/src/lifetable.js
@@ -1,20 +1,34 @@
 // Actuarial life-expectancy data + estimator. Zero dependencies, pure functions.
 //
-// Source: U.S. Social Security Administration, "Actuarial Life Table" —
-// Period Life Table, 2023 (as used in the 2026 Trustees Report).
-// https://www.ssa.gov/oact/STATS/table4c6.html
+// WORLD SOURCE: United Nations, Department of Economic and Social Affairs,
+// Population Division (2024), World Population Prospects 2024. The arrays below
+// are the World, 2023, Medium-variant `ex` columns extracted from the complete
+// male, female, and both-sexes life-table CSVs and converted to JavaScript arrays
+// (ages 0..99 plus the official 100+ endpoint):
+// https://population.un.org/wpp/
+// https://population.un.org/wpp/assets/Excel%20Files/1_Indicator%20(Standard)/CSV_FILES/
+// WPP2024_Life_Table_Complete_Medium_Male_1950-2023.csv.gz
+// WPP2024_Life_Table_Complete_Medium_Female_1950-2023.csv.gz
+// WPP2024_Life_Table_Complete_Medium_Both_1950-2023.csv.gz
 //
+// UN data is licensed CC BY 3.0 IGO:
+// https://creativecommons.org/licenses/by/3.0/igo/
+// Redistribution and adaptation are permitted with attribution; this project is
+// not endorsed by the United Nations. See THIRD_PARTY_NOTICES.txt.
+//
+// UNITED STATES SOURCE: U.S. Social Security Administration, "Actuarial Life
+// Table" — Period Life Table, 2023 (as used in the 2026 Trustees Report).
+// https://www.ssa.gov/oact/STATS/table4c6.html
 // Works of the U.S. federal government are in the PUBLIC DOMAIN (17 U.S.C. Sec.
-// 105), so this table is safe to embed under the project's MIT, zero-dependency
-// ethos. (WHO GHO life-expectancy data is deliberately NOT used: its
-// CC BY-NC-SA licensing is incompatible with embedding here.)
+// 105). WHO GHO data is deliberately NOT used because its CC BY-NC-SA terms are
+// incompatible with embedding here.
 //
 // MALE and FEMALE below are the e(x) column — the expectation of remaining years
-// of life at exact integer age x — for x = 0..119. Spot-check values from the
-// source table: MALE e(0)=75.79, e(65)=18.12, e(100)=2.04; FEMALE e(0)=81.06,
-// e(65)=20.66, e(100)=2.23. The table's own invariants hold across every age:
-// e(x) is non-increasing, the total x+e(x) is non-decreasing, and FEMALE e(x) is
-// >= MALE e(x) everywhere.
+// of life at exact integer age x — for x = 0..119 in the SSA table. WORLD_MALE
+// and WORLD_FEMALE are the equivalent World series for ages 0..100. Spot checks:
+// SSA male e(0)=75.79, e(65)=18.12; SSA female e(0)=81.06, e(65)=20.66.
+// UN World male e(0)=70.5472, e(65)=16.0083; UN World female e(0)=75.8857,
+// e(65)=18.9811.
 
 /** Male expectation of remaining life e(x), by integer age x = 0..119 (years). */
 export const MALE = [
@@ -47,46 +61,123 @@ export const FEMALE = [
 ];
 
 /**
- * Unisex expectation of remaining life: the simple average of MALE and FEMALE at
- * each age. Used when the user hasn't shared a sex at birth.
+ * U.S. unisex expectation of remaining life: the simple average of MALE and
+ * FEMALE at each age.
  */
 export const UNISEX = MALE.map((m, i) => (m + FEMALE[i]) / 2);
 
-/** The e(x) table for a given sex; unknown/null falls back to UNISEX. */
-function tableFor(sex) {
-  if (sex === "male") return MALE;
-  if (sex === "female") return FEMALE;
-  return UNISEX;
+/** UN World male expectation of remaining life e(x), ages 0..100 (years). */
+export const WORLD_MALE = [
+  70.5472, 71.6729, 70.9245, 70.0974, 69.2331, 68.3454, 67.4395, 66.5183,
+  65.5849, 64.6414, 63.6901, 62.7336, 61.7747, 60.8156, 59.8585, 58.9056,
+  57.959, 57.0199, 56.089, 55.1661, 54.2497, 53.3382, 52.4297, 51.522, 50.6144,
+  49.7065, 48.7978, 47.8881, 46.9777, 46.0669, 45.156, 44.2454, 43.3353,
+  42.4251, 41.5153, 40.6074, 39.7012, 38.7971, 37.8961, 36.9988, 36.1058,
+  35.2173, 34.3323, 33.4528, 32.5785, 31.7094, 30.8452, 29.9849, 29.1287,
+  28.2771, 27.4314, 26.5939, 25.7658, 24.948, 24.1407, 23.3437, 22.5574,
+  21.7815, 21.0141, 20.2561, 19.5098, 18.7773, 18.0628, 17.3651, 16.6807,
+  16.0083, 15.3468, 14.6979, 14.0605, 13.4347, 12.823, 12.225, 11.64, 11.0676,
+  10.5054, 9.961, 9.4238, 8.8972, 8.3893, 7.9004, 7.428, 6.975, 6.5449, 6.1348,
+  5.7434, 5.3739, 5.0232, 4.6898, 4.3767, 4.0827, 3.811, 3.5576, 3.3205, 3.1026,
+  2.9054, 2.7267, 2.5655, 2.4195, 2.2894, 2.1752, 2.0733,
+];
+
+/** UN World female expectation of remaining life e(x), ages 0..100 (years). */
+export const WORLD_FEMALE = [
+  75.8857, 76.8368, 76.1002, 75.2757, 74.4126, 73.5264, 72.6227, 71.7042,
+  70.7734, 69.8318, 68.8814, 67.9249, 66.9652, 66.0048, 65.0457, 64.0893,
+  63.1366, 62.1876, 61.2417, 60.2982, 59.3557, 58.4136, 57.4717, 56.53, 55.5889,
+  54.6486, 53.7089, 52.7701, 51.8317, 50.8936, 49.9556, 49.0179, 48.0799,
+  47.1415, 46.2033, 45.266, 44.3299, 43.3952, 42.4629, 41.5334, 40.6069,
+  39.6831, 38.762, 37.8448, 36.9311, 36.0211, 35.1145, 34.2102, 33.3081,
+  32.4086, 31.5125, 30.6213, 29.736, 28.8574, 27.9866, 27.1242, 26.271, 25.4266,
+  24.5884, 23.7568, 22.9319, 22.1168, 21.3163, 20.5288, 19.7506, 18.9811,
+  18.2196, 17.468, 16.727, 15.9966, 15.2795, 14.5748, 13.8834, 13.2064, 12.5426,
+  11.9002, 11.2724, 10.6605, 10.0716, 9.5049, 8.9558, 8.4266, 7.9194, 7.4329,
+  6.9666, 6.5228, 6.098, 5.6918, 5.3058, 4.9401, 4.5958, 4.2718, 3.9671, 3.6851,
+  3.4265, 3.1902, 2.9708, 2.7686, 2.5843, 2.4183, 2.269,
+];
+
+/** UN World official both-sexes expectation of remaining life, ages 0..100. */
+export const WORLD_BOTH = [
+  73.1694, 74.216, 73.4736, 72.6481, 71.7845, 70.8978, 69.9931, 69.0733,
+  68.1412, 67.1987, 66.2479, 65.2915, 64.3323, 63.3727, 62.4148, 61.4604,
+  60.5111, 59.5676, 58.6299, 57.6977, 56.7694, 55.844, 54.9202, 53.9971,
+  53.0742, 52.1516, 51.2288, 50.3059, 49.383, 48.4598, 47.5367, 46.6139,
+  45.6912, 44.7683, 43.8457, 42.9246, 42.0049, 41.087, 40.1719, 39.26, 38.352,
+  37.4475, 36.5463, 35.6499, 34.7579, 33.8704, 32.9872, 32.1071, 31.2302,
+  30.3571, 29.4887, 28.6271, 27.7732, 26.9281, 26.0923, 25.2659, 24.4495,
+  23.6429, 22.8437, 22.0527, 21.2711, 20.5014, 19.7481, 19.0098, 18.2827,
+  17.5661, 16.8589, 16.1629, 15.4776, 14.8034, 14.1426, 13.4946, 12.8595,
+  12.2377, 11.6275, 11.037, 10.4574, 9.8912, 9.3459, 8.8213, 8.3138, 7.8258,
+  7.3595, 6.9131, 6.4856, 6.0801, 5.693, 5.3233, 4.9732, 4.6422, 4.3323, 4.0405,
+  3.7659, 3.5116, 3.2785, 3.0651, 2.8673, 2.6847, 2.5176, 2.3666, 2.2298,
+];
+
+/** The official World both-sexes series used when sex is not shared. */
+export const WORLD_UNISEX = WORLD_BOTH;
+
+export const DEFAULT_LIFE_TABLE = "world";
+
+/** Stable state values and user-facing labels for actuarial baselines. */
+export const LIFE_TABLE_OPTIONS = Object.freeze([
+  Object.freeze({ value: "world", label: "World — UN 2023" }),
+  Object.freeze({ value: "us", label: "United States — SSA 2023" }),
+]);
+
+const TABLES = {
+  world: {
+    male: WORLD_MALE,
+    female: WORLD_FEMALE,
+    unisex: WORLD_UNISEX,
+  },
+  us: { male: MALE, female: FEMALE, unisex: UNISEX },
+};
+
+/** Normalize persisted/imported table ids; unknown values use the World baseline. */
+export function normalizeLifeTable(value) {
+  return value === "us" ? "us" : DEFAULT_LIFE_TABLE;
+}
+
+/** The e(x) table for a given sex and baseline; unknown/null sex uses unisex. */
+function tableFor(sex, lifeTable) {
+  const tables = TABLES[normalizeLifeTable(lifeTable)];
+  if (sex === "male") return tables.male;
+  if (sex === "female") return tables.female;
+  return tables.unisex;
 }
 
 /**
  * Estimate the total expected age at death for someone who has ALREADY attained
- * `ageYears`, conditioned on an optional sex at birth. Life expectancy is
- * conditional on survival: e(x) is the expected REMAINING years at exact age x,
- * so the total expected age is x + e(x), which rises with attained age (a 70-year
- * old outlives the at-birth average). e(x) is linearly interpolated between
- * integer ages for smoothness, and the final total is rounded to a whole year.
+ * `ageYears`, conditioned on an optional sex at birth and named actuarial
+ * baseline. Life expectancy is conditional on survival: e(x) is the expected
+ * REMAINING years at exact age x, so the total expected age is x + e(x), which
+ * rises with attained age. e(x) is linearly interpolated between integer ages
+ * for smoothness, and the final total is rounded to a whole year.
  *
  * The attained age is clamped to the table's bounds [0, last index] before
- * lookup; the result is guaranteed to be >= the attained age and to sit within
- * the app's supported expectancy band [1, 150].
+ * lookup; the result sits within the app's supported expectancy band [1, 150]
+ * and never falls below an attained age inside that band.
  *
  * @param {number} ageYears Attained age in years (may be fractional).
  * @param {"male"|"female"|null} [sex] Sex at birth; null/omitted uses UNISEX.
+ * @param {"world"|"us"} [lifeTable] Actuarial baseline; defaults to World.
  * @returns {number} Whole-number total expected age at death.
  */
-export function estimateExpectancy(ageYears, sex) {
-  const table = tableFor(sex);
+export function estimateExpectancy(
+  ageYears,
+  sex,
+  lifeTable = DEFAULT_LIFE_TABLE,
+) {
+  const table = tableFor(sex, lifeTable);
   const last = table.length - 1;
-  const age = Math.min(
-    last,
-    Math.max(0, Number.isFinite(ageYears) ? ageYears : 0),
-  );
+  const attainedAge = Number.isFinite(ageYears) ? Math.max(0, ageYears) : 0;
+  const age = Math.min(last, attainedAge);
   const lo = Math.floor(age);
   const hi = Math.min(last, lo + 1);
   // Interpolate e(x) between the two bracketing integer ages.
   const ex = table[lo] + (table[hi] - table[lo]) * (age - lo);
   const total = Math.round(age + ex);
   // Never below the person's current age; keep inside the app's clamp [1, 150].
-  return Math.min(150, Math.max(1, Math.ceil(age), total));
+  return Math.min(150, Math.max(1, Math.ceil(attainedAge), total));
 }

--- a/src/lifetable.js
+++ b/src/lifetable.js
@@ -136,7 +136,10 @@ const TABLES = {
 
 /** Normalize persisted/imported table ids; unknown values use the World baseline. */
 export function normalizeLifeTable(value) {
-  return value === "us" ? "us" : DEFAULT_LIFE_TABLE;
+  return typeof value === "string" &&
+    Object.prototype.hasOwnProperty.call(TABLES, value)
+    ? value
+    : DEFAULT_LIFE_TABLE;
 }
 
 /** The e(x) table for a given sex and baseline; unknown/null sex uses unisex. */

--- a/src/store.js
+++ b/src/store.js
@@ -1,7 +1,11 @@
 // Persistence + theming. No dependencies, runs directly in the browser.
 
 import { detectZone } from "./time.js";
-import { estimateExpectancy } from "./lifetable.js";
+import {
+  DEFAULT_LIFE_TABLE,
+  estimateExpectancy,
+  normalizeLifeTable,
+} from "./lifetable.js";
 
 const KEY = "mortality";
 
@@ -82,6 +86,7 @@ const DEFAULTS = {
   expectancy: 80,
   expectancySource: "estimate",
   sex: null,
+  lifeTable: DEFAULT_LIFE_TABLE,
   mode: "years",
   typeface: "system",
   reflection: false,
@@ -108,7 +113,7 @@ export function clampExpectancy(value) {
  * derive an actuarial estimate from their age and optional sex at birth. Falls
  * back to the clamped custom value whenever the age can't be computed (e.g. no
  * birthday yet), so the counter always has a sane denominator. Pure.
- * @param {{expectancySource?: string, expectancy?: unknown, sex?: string|null}} state
+ * @param {{expectancySource?: string, expectancy?: unknown, sex?: string|null, lifeTable?: string}} state
  * @param {number} ageYears Attained age in years (may be fractional or NaN).
  * @returns {number}
  */
@@ -117,7 +122,11 @@ export function effectiveExpectancy(state, ageYears) {
   const custom = clampExpectancy(state && state.expectancy);
   if (source === "custom") return custom;
   if (!Number.isFinite(ageYears)) return custom;
-  return estimateExpectancy(ageYears, state ? state.sex : null);
+  return estimateExpectancy(
+    ageYears,
+    state ? state.sex : null,
+    state ? state.lifeTable : DEFAULT_LIFE_TABLE,
+  );
 }
 
 // Extension storage.local persists across the privacy/history clearing that can
@@ -198,8 +207,9 @@ function backfillZone(state) {
  * any record that already lived on disk before this feature lacked the field, so
  * it's pinned to "custom" — preserving the exact number that user has always
  * seen (their flat 80, or whatever they set) rather than silently swapping in an
- * age-based estimate on update. `sex` is backfilled to null when absent. Returns
- * the state unchanged (same reference) when there is nothing to migrate.
+ * age-based estimate on update. `sex` is backfilled to null and `lifeTable` to
+ * the neutral World baseline when absent. Returns the state unchanged (same
+ * reference) when there is nothing to migrate.
  * @param {object} state  State already merged over DEFAULTS.
  * @param {object|null|undefined} raw  The record as read from storage/legacy.
  */
@@ -208,6 +218,12 @@ function migrateExpectancy(state, raw) {
   const patch = {};
   if (!("expectancySource" in raw)) patch.expectancySource = "custom";
   if (!("sex" in raw)) patch.sex = null;
+  if (
+    !("lifeTable" in raw) ||
+    normalizeLifeTable(raw.lifeTable) !== raw.lifeTable
+  ) {
+    patch.lifeTable = DEFAULT_LIFE_TABLE;
+  }
   return Object.keys(patch).length ? { ...state, ...patch } : state;
 }
 
@@ -219,7 +235,7 @@ function migrateExpectancy(state, raw) {
  * forward without changing the age shown today. Records that predate the
  * actuarial-expectancy feature keep their flat number by being pinned to a
  * "custom" expectancy source (see migrateExpectancy).
- * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, expectancySource: string, sex: string|null, mode: string, typeface: string, reflection: boolean }>}
+ * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, expectancySource: string, sex: string|null, lifeTable: string, mode: string, typeface: string, reflection: boolean }>}
  */
 export async function load() {
   let stored;

--- a/src/tab.css
+++ b/src/tab.css
@@ -67,6 +67,14 @@ body {
   padding: 1.5rem;
 }
 
+/* These forms can grow beyond a short viewport. Keep them centred when they
+   fit, but let the body expand from the top when they need to scroll. */
+body.screen-setup,
+body.screen-settings {
+  height: auto;
+  min-height: 100%;
+}
+
 /* Counter screen: break dead-centre for an editorial lower-left composition.
    Setup and settings keep the default centred layout. */
 body.screen-counter {
@@ -489,6 +497,7 @@ footer {
 }
 
 .row select {
+  max-width: min(15rem, 58vw);
   padding: 0.25rem 0.5rem;
   font-size: 1rem;
   font-family: inherit;

--- a/src/tab.js
+++ b/src/tab.js
@@ -28,7 +28,11 @@ import {
   nextBirthdayInstantMs,
   parseBirthParts,
 } from "./time.js";
-import { estimateExpectancy } from "./lifetable.js";
+import {
+  estimateExpectancy,
+  LIFE_TABLE_OPTIONS,
+  normalizeLifeTable,
+} from "./lifetable.js";
 import { el } from "./dom.js";
 
 const YEAR_MS = 31556900000; // milliseconds per year (preserved from v1.2)
@@ -147,6 +151,12 @@ export function mergeImported(current, imported) {
       : current.expectancySource;
   if ("sex" in src)
     known.sex = src.sex === "male" || src.sex === "female" ? src.sex : null;
+  if ("lifeTable" in src)
+    known.lifeTable = LIFE_TABLE_OPTIONS.some(
+      ({ value }) => value === src.lifeTable,
+    )
+      ? src.lifeTable
+      : current.lifeTable;
   if ("mode" in src && MODES.includes(src.mode)) known.mode = src.mode;
   if ("typeface" in src)
     known.typeface = TYPEFACES.includes(src.typeface) ? src.typeface : "system";
@@ -157,13 +167,21 @@ export function mergeImported(current, imported) {
 function showSetup() {
   stopTimer();
   setScreen("setup");
-  renderSetup(app, { start }, state.birth, state.birthZone, state.sex);
+  renderSetup(
+    app,
+    { start },
+    state.birth,
+    state.birthZone,
+    state.sex,
+    state.lifeTable,
+  );
 }
 
-function start(birth, zone, sex) {
+function start(birth, zone, sex, lifeTable) {
   state.birth = birth;
   state.birthZone = zone || detectZone();
   state.sex = sex === "male" || sex === "female" ? sex : null;
+  state.lifeTable = normalizeLifeTable(lifeTable);
   save(state);
   showCounter();
 }
@@ -433,6 +451,11 @@ function showSettings() {
         // Re-render so the estimate line reflects the new sex immediately.
         showSettings();
       },
+      setLifeTable(value) {
+        state.lifeTable = normalizeLifeTable(value);
+        save(state);
+        showSettings();
+      },
       resetColors() {
         state.theme = null;
         save(state);
@@ -508,6 +531,7 @@ function showSettings() {
       expectancySource:
         state.expectancySource === "custom" ? "custom" : "estimate",
       sex: state.sex === "male" || state.sex === "female" ? state.sex : null,
+      lifeTable: normalizeLifeTable(state.lifeTable),
       estimate: settingsEstimate(),
       typeface: state.typeface,
       reflection: state.reflection,
@@ -525,7 +549,7 @@ function settingsEstimate() {
   const bornMs = birthInstantMs(state.birth, zone);
   const ageYears = ageYearsFrom(bornMs, Date.now());
   return Number.isFinite(ageYears)
-    ? estimateExpectancy(ageYears, state.sex)
+    ? estimateExpectancy(ageYears, state.sex, state.lifeTable)
     : null;
 }
 

--- a/src/views.js
+++ b/src/views.js
@@ -199,13 +199,13 @@ export function renderSetup(
       el(
         "label",
         { class: "setup-label", for: "birth-life-table" },
-        "Actuarial baseline",
+        "Life expectancy data source",
       ),
       lifeTableEl,
       el(
         "p",
         { class: "hint" },
-        "World by default. Chosen explicitly — never inferred from your time zone.",
+        "World data by default. Your time zone never changes this choice.",
       ),
     ]),
     el("div", { class: "setup-field" }, [
@@ -441,8 +441,8 @@ export function renderSettings(
     "p",
     { class: "settings-hint", id: "expectancy-estimate" },
     estimate != null
-      ? `\u2248 ${estimate} years \u2014 actuarial estimate for your age.`
-      : "Add your birthday to see an actuarial estimate.",
+      ? `\u2248 ${estimate} years \u2014 based on your age and selected data.`
+      : "Add your birthday to see an estimate.",
   );
   const customRow = el("div", { class: "row" }, [
     el("label", { for: "expectancy" }, "Years"),
@@ -453,7 +453,7 @@ export function renderSettings(
     actions.setLifeTable(lifeTableEl.value),
   );
   const lifeTableRow = el("div", { class: "row" }, [
-    el("label", { for: "settings-life-table" }, "Baseline"),
+    el("label", { for: "settings-life-table" }, "Data source"),
     lifeTableEl,
   ]);
   const sexEl = sexSelect("settings-sex", sex);
@@ -568,7 +568,7 @@ export function renderSettings(
           el(
             "p",
             { class: "settings-hint" },
-            "Baseline is never inferred from your time zone. Sex at birth is optional.",
+            "Your time zone never changes the data source. Sex at birth is optional.",
           ),
         ]
       : [customRow]),

--- a/src/views.js
+++ b/src/views.js
@@ -9,6 +9,11 @@ import {
   bestOnColor,
 } from "./store.js";
 import { listTimeZones, detectZone } from "./time.js";
+import {
+  DEFAULT_LIFE_TABLE,
+  LIFE_TABLE_OPTIONS,
+  normalizeLifeTable,
+} from "./lifetable.js";
 import { el } from "./dom.js";
 
 const COLOR_LABELS = {
@@ -95,6 +100,19 @@ function sexSelect(id, current) {
   return select;
 }
 
+/** An explicit actuarial-baseline picker; never inferred from time zone. */
+function lifeTableSelect(id, current) {
+  const select = el(
+    "select",
+    { id },
+    LIFE_TABLE_OPTIONS.map(({ value, label }) =>
+      el("option", { value }, label),
+    ),
+  );
+  select.value = normalizeLifeTable(current || DEFAULT_LIFE_TABLE);
+  return select;
+}
+
 /** Today as YYYY-MM-DD in local time, used to cap the birth-date field. */
 function todayISO() {
   const now = new Date();
@@ -109,8 +127,15 @@ function splitBirth(value) {
   return [date, time.slice(0, 5)];
 }
 
-/** Birthday entry screen. `current`/`savedZone`/`savedSex` pre-fill when editing. */
-export function renderSetup(app, { start }, current, savedZone, savedSex) {
+/** Birthday entry screen. Stored values pre-fill when editing. */
+export function renderSetup(
+  app,
+  { start },
+  current,
+  savedZone,
+  savedSex,
+  savedLifeTable,
+) {
   const dateEl = el("input", {
     type: "date",
     id: "birth-date",
@@ -135,6 +160,7 @@ export function renderSetup(app, { start }, current, savedZone, savedSex) {
   );
   zoneEl.value = selectedZone;
   const sexEl = sexSelect("birth-sex", savedSex);
+  const lifeTableEl = lifeTableSelect("birth-life-table", savedLifeTable);
   const startBtn = el("button", { id: "start" }, "Start");
   const errorEl = el("p", {
     class: "field-error",
@@ -170,6 +196,19 @@ export function renderSetup(app, { start }, current, savedZone, savedSex) {
       ),
     ]),
     el("div", { class: "setup-field" }, [
+      el(
+        "label",
+        { class: "setup-label", for: "birth-life-table" },
+        "Actuarial baseline",
+      ),
+      lifeTableEl,
+      el(
+        "p",
+        { class: "hint" },
+        "World by default. Chosen explicitly — never inferred from your time zone.",
+      ),
+    ]),
+    el("div", { class: "setup-field" }, [
       el("label", { class: "setup-label", for: "birth-sex" }, "Sex at birth"),
       sexEl,
       el(
@@ -201,7 +240,7 @@ export function renderSetup(app, { start }, current, savedZone, savedSex) {
       return;
     }
     errorEl.hidden = true;
-    start(birth, zoneEl.value, sexEl.value || null);
+    start(birth, zoneEl.value, sexEl.value || null, lifeTableEl.value);
   }
   form.addEventListener("submit", (event) => {
     event.preventDefault();
@@ -212,7 +251,7 @@ export function renderSetup(app, { start }, current, savedZone, savedSex) {
       errorEl.hidden = true;
     }),
   );
-  [dateEl, timeEl, zoneEl, sexEl].forEach((input) =>
+  [dateEl, timeEl, zoneEl, lifeTableEl, sexEl].forEach((input) =>
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
         event.preventDefault();
@@ -309,6 +348,7 @@ export function renderSettings(
     expectancy,
     expectancySource,
     sex,
+    lifeTable,
     estimate,
     typeface,
     reflection,
@@ -407,6 +447,14 @@ export function renderSettings(
   const customRow = el("div", { class: "row" }, [
     el("label", { for: "expectancy" }, "Years"),
     expectancyInput,
+  ]);
+  const lifeTableEl = lifeTableSelect("settings-life-table", lifeTable);
+  lifeTableEl.addEventListener("change", () =>
+    actions.setLifeTable(lifeTableEl.value),
+  );
+  const lifeTableRow = el("div", { class: "row" }, [
+    el("label", { for: "settings-life-table" }, "Baseline"),
+    lifeTableEl,
   ]);
   const sexEl = sexSelect("settings-sex", sex);
   sexEl.addEventListener("change", () => actions.setSex(sexEl.value || null));
@@ -512,13 +560,18 @@ export function renderSettings(
       el("label", { id: "expectancy-source-label" }, "Source"),
       sourceSegment,
     ]),
-    useEstimate ? estimateLine : customRow,
-    sexRow,
-    el(
-      "p",
-      { class: "settings-hint" },
-      "Optional — sharpens the life-expectancy estimate.",
-    ),
+    ...(useEstimate
+      ? [
+          lifeTableRow,
+          estimateLine,
+          sexRow,
+          el(
+            "p",
+            { class: "settings-hint" },
+            "Baseline is never inferred from your time zone. Sex at birth is optional.",
+          ),
+        ]
+      : [customRow]),
     el("p", { class: "settings-label" }, "Time zone"),
     el("div", { class: "setup-field" }, [
       el("label", { class: "setup-label", for: "settings-zone" }, "Born in"),

--- a/test/lifetable.test.js
+++ b/test/lifetable.test.js
@@ -1,16 +1,35 @@
 import { describe, it, expect } from "vitest";
-import { MALE, FEMALE, UNISEX, estimateExpectancy } from "../src/lifetable.js";
+import {
+  DEFAULT_LIFE_TABLE,
+  FEMALE,
+  LIFE_TABLE_OPTIONS,
+  MALE,
+  UNISEX,
+  WORLD_BOTH,
+  WORLD_FEMALE,
+  WORLD_MALE,
+  WORLD_UNISEX,
+  estimateExpectancy,
+  normalizeLifeTable,
+} from "../src/lifetable.js";
 
-const AGES = Array.from({ length: 120 }, (_, x) => x);
+const US_AGES = Array.from({ length: 120 }, (_, age) => age);
+const WORLD_AGES = Array.from({ length: 101 }, (_, age) => age);
+
+function expectTotalAgeToRise(table) {
+  for (let age = 1; age < table.length; age++) {
+    expect(age + table[age]).toBeGreaterThanOrEqual(age - 1 + table[age - 1]);
+  }
+}
 
 describe("life table data", () => {
-  it("covers integer ages 0..119 for both sexes", () => {
+  it("covers SSA integer ages 0..119", () => {
     expect(MALE.length).toBe(120);
     expect(FEMALE.length).toBe(120);
     expect(UNISEX.length).toBe(120);
   });
 
-  it("matches the SSA source spot values (Period Life Table, 2023)", () => {
+  it("matches SSA Period Life Table 2023 spot values", () => {
     expect(MALE[0]).toBeCloseTo(75.79, 2);
     expect(MALE[65]).toBeCloseTo(18.12, 2);
     expect(MALE[100]).toBeCloseTo(2.04, 2);
@@ -19,76 +38,154 @@ describe("life table data", () => {
     expect(FEMALE[100]).toBeCloseTo(2.23, 2);
   });
 
-  it("derives UNISEX as the simple average of MALE and FEMALE", () => {
-    for (const x of AGES) {
-      expect(UNISEX[x]).toBeCloseTo((MALE[x] + FEMALE[x]) / 2, 10);
+  it("covers UN World ages 0..99 plus the 100+ endpoint", () => {
+    expect(WORLD_MALE.length).toBe(101);
+    expect(WORLD_FEMALE.length).toBe(101);
+    expect(WORLD_BOTH.length).toBe(101);
+    expect(WORLD_UNISEX.length).toBe(101);
+  });
+
+  it("matches UN WPP 2024 World 2023 spot values", () => {
+    expect(WORLD_MALE[0]).toBeCloseTo(70.5472, 4);
+    expect(WORLD_MALE[65]).toBeCloseTo(16.0083, 4);
+    expect(WORLD_MALE[100]).toBeCloseTo(2.0733, 4);
+    expect(WORLD_FEMALE[0]).toBeCloseTo(75.8857, 4);
+    expect(WORLD_FEMALE[65]).toBeCloseTo(18.9811, 4);
+    expect(WORLD_FEMALE[100]).toBeCloseTo(2.269, 4);
+    expect(WORLD_BOTH[0]).toBeCloseTo(73.1694, 4);
+    expect(WORLD_BOTH[65]).toBeCloseTo(17.5661, 4);
+    expect(WORLD_BOTH[100]).toBeCloseTo(2.2298, 4);
+  });
+
+  it("derives the SSA unisex table as the simple male/female average", () => {
+    for (const age of US_AGES) {
+      expect(UNISEX[age]).toBeCloseTo((MALE[age] + FEMALE[age]) / 2, 10);
     }
   });
 
-  it("has a non-increasing e(x) with age (remaining life shrinks)", () => {
-    for (const table of [MALE, FEMALE, UNISEX]) {
-      for (let x = 1; x < table.length; x++) {
-        expect(table[x]).toBeLessThanOrEqual(table[x - 1] + 1e-9);
-      }
+  it("uses the official UN both-sexes series for the World unisex table", () => {
+    for (const age of WORLD_AGES) {
+      expect(WORLD_UNISEX[age]).toBe(WORLD_BOTH[age]);
+      expect(WORLD_UNISEX[age]).toBeGreaterThanOrEqual(WORLD_MALE[age]);
+      expect(WORLD_UNISEX[age]).toBeLessThanOrEqual(WORLD_FEMALE[age]);
     }
   });
 
-  it("keeps female e(x) at or above male e(x) at every age", () => {
-    for (const x of AGES) {
-      expect(FEMALE[x]).toBeGreaterThanOrEqual(MALE[x]);
+  it("keeps total expected age non-decreasing in every table", () => {
+    for (const table of [
+      MALE,
+      FEMALE,
+      UNISEX,
+      WORLD_MALE,
+      WORLD_FEMALE,
+      WORLD_BOTH,
+      WORLD_UNISEX,
+    ]) {
+      expectTotalAgeToRise(table);
+    }
+  });
+
+  it("keeps female e(x) at or above male e(x) in each baseline", () => {
+    for (const age of US_AGES) {
+      expect(FEMALE[age]).toBeGreaterThanOrEqual(MALE[age]);
+    }
+    for (const age of WORLD_AGES) {
+      expect(WORLD_FEMALE[age]).toBeGreaterThanOrEqual(WORLD_MALE[age]);
     }
   });
 });
 
+describe("life-table baseline metadata", () => {
+  it("defaults to World and exposes explicit World and U.S. choices", () => {
+    expect(DEFAULT_LIFE_TABLE).toBe("world");
+    expect(LIFE_TABLE_OPTIONS.map(({ value }) => value)).toEqual([
+      "world",
+      "us",
+    ]);
+    expect(LIFE_TABLE_OPTIONS[0].label).toContain("UN 2023");
+    expect(LIFE_TABLE_OPTIONS[1].label).toContain("SSA 2023");
+  });
+
+  it("normalizes unknown values to World", () => {
+    expect(normalizeLifeTable("world")).toBe("world");
+    expect(normalizeLifeTable("us")).toBe("us");
+    expect(normalizeLifeTable("unknown")).toBe("world");
+    expect(normalizeLifeTable(null)).toBe("world");
+  });
+});
+
 describe("estimateExpectancy", () => {
-  it("returns a plausible at-birth expectancy for each sex", () => {
-    // Recent SSA period tables: e(0) male ~73-76, female ~79-82.
-    expect(estimateExpectancy(0, "male")).toBeGreaterThanOrEqual(73);
-    expect(estimateExpectancy(0, "male")).toBeLessThanOrEqual(76);
-    expect(estimateExpectancy(0, "female")).toBeGreaterThanOrEqual(79);
-    expect(estimateExpectancy(0, "female")).toBeLessThanOrEqual(82);
+  it("uses the World baseline by default", () => {
+    expect(estimateExpectancy(0, "male")).toBe(
+      estimateExpectancy(0, "male", "world"),
+    );
+    expect(estimateExpectancy(0, "male")).toBe(71);
+    expect(estimateExpectancy(0, "female")).toBe(76);
+  });
+
+  it("can select the U.S. SSA baseline explicitly", () => {
+    expect(estimateExpectancy(0, "male", "us")).toBe(76);
+    expect(estimateExpectancy(0, "female", "us")).toBe(81);
+    expect(estimateExpectancy(65, "male", "us")).toBe(83);
+  });
+
+  it("falls back to World for an unknown baseline", () => {
+    expect(estimateExpectancy(40, null, "unknown")).toBe(
+      estimateExpectancy(40, null, "world"),
+    );
   });
 
   it("always returns a whole number", () => {
-    for (const x of [0, 12.4, 40, 65.5, 90, 119]) {
+    for (const age of [0, 12.4, 40, 65.5, 90, 119]) {
       for (const sex of ["male", "female", null]) {
-        expect(Number.isInteger(estimateExpectancy(x, sex))).toBe(true);
+        for (const lifeTable of ["world", "us"]) {
+          expect(
+            Number.isInteger(estimateExpectancy(age, sex, lifeTable)),
+          ).toBe(true);
+        }
       }
     }
   });
 
-  it("never returns less than the attained age", () => {
-    for (const x of AGES) {
-      expect(estimateExpectancy(x, "male")).toBeGreaterThanOrEqual(x);
-      expect(estimateExpectancy(x, "female")).toBeGreaterThanOrEqual(x);
-      expect(estimateExpectancy(x, null)).toBeGreaterThanOrEqual(x);
+  it("never returns less than the attained age inside the app range", () => {
+    for (const age of [0, 40.5, 100, 119, 149]) {
+      for (const lifeTable of ["world", "us"]) {
+        expect(
+          estimateExpectancy(age, "male", lifeTable),
+        ).toBeGreaterThanOrEqual(Math.ceil(age));
+      }
     }
   });
 
   it("has a total expected age that rises with attained age", () => {
-    for (const sex of ["male", "female", null]) {
-      for (let x = 1; x < 120; x++) {
-        expect(estimateExpectancy(x, sex)).toBeGreaterThanOrEqual(
-          estimateExpectancy(x - 1, sex),
-        );
+    for (const lifeTable of ["world", "us"]) {
+      for (const sex of ["male", "female", null]) {
+        for (let age = 1; age < 120; age++) {
+          expect(
+            estimateExpectancy(age, sex, lifeTable),
+          ).toBeGreaterThanOrEqual(estimateExpectancy(age - 1, sex, lifeTable));
+        }
       }
     }
   });
 
-  it("estimates a higher total for older users than the flat at-birth figure", () => {
-    // Conditioning on survival: a 70-year-old outlives the at-birth average.
-    expect(estimateExpectancy(70, "male")).toBeGreaterThan(
-      estimateExpectancy(0, "male"),
-    );
+  it("conditions on survival instead of keeping the at-birth figure flat", () => {
+    for (const lifeTable of ["world", "us"]) {
+      expect(estimateExpectancy(70, "male", lifeTable)).toBeGreaterThan(
+        estimateExpectancy(0, "male", lifeTable),
+      );
+    }
   });
 
-  it("orders the sexes: female >= unisex >= male at a given age", () => {
-    for (const x of [0, 25, 50, 70, 90]) {
-      const male = estimateExpectancy(x, "male");
-      const female = estimateExpectancy(x, "female");
-      const unisex = estimateExpectancy(x, null);
-      expect(female).toBeGreaterThanOrEqual(unisex);
-      expect(unisex).toBeGreaterThanOrEqual(male);
+  it("orders the sexes: female >= unisex >= male", () => {
+    for (const lifeTable of ["world", "us"]) {
+      for (const age of [0, 25, 50, 70, 90]) {
+        const male = estimateExpectancy(age, "male", lifeTable);
+        const female = estimateExpectancy(age, "female", lifeTable);
+        const unisex = estimateExpectancy(age, null, lifeTable);
+        expect(female).toBeGreaterThanOrEqual(unisex);
+        expect(unisex).toBeGreaterThanOrEqual(male);
+      }
     }
   });
 
@@ -100,27 +197,32 @@ describe("estimateExpectancy", () => {
   });
 
   it("interpolates e(x) smoothly between integer ages", () => {
-    // The half-year point sits between the two bracketing integer totals.
-    const lo = estimateExpectancy(40, "male");
-    const hi = estimateExpectancy(41, "male");
-    const mid = estimateExpectancy(40.5, "male");
-    expect(mid).toBeGreaterThanOrEqual(Math.min(lo, hi));
-    expect(mid).toBeLessThanOrEqual(Math.max(lo, hi));
+    for (const lifeTable of ["world", "us"]) {
+      const lo = estimateExpectancy(40, "male", lifeTable);
+      const hi = estimateExpectancy(41, "male", lifeTable);
+      const mid = estimateExpectancy(40.5, "male", lifeTable);
+      expect(mid).toBeGreaterThanOrEqual(Math.min(lo, hi));
+      expect(mid).toBeLessThanOrEqual(Math.max(lo, hi));
+    }
   });
 
-  it("clamps the attained age to the table bounds", () => {
-    // Below 0 and above the last index resolve to the endpoint estimates.
-    expect(estimateExpectancy(-10, "male")).toBe(estimateExpectancy(0, "male"));
-    expect(estimateExpectancy(500, "male")).toBe(
-      estimateExpectancy(119, "male"),
+  it("clamps table lookup at each source's endpoint without going below age", () => {
+    expect(estimateExpectancy(-10, "male", "world")).toBe(
+      estimateExpectancy(0, "male", "world"),
     );
+    expect(estimateExpectancy(105, "male", "world")).toBeGreaterThanOrEqual(
+      105,
+    );
+    expect(estimateExpectancy(125, "male", "us")).toBeGreaterThanOrEqual(125);
   });
 
   it("keeps the result inside the app's [1, 150] band", () => {
-    for (const x of [-100, 0, 60, 119, 1000]) {
-      const value = estimateExpectancy(x, "female");
-      expect(value).toBeGreaterThanOrEqual(1);
-      expect(value).toBeLessThanOrEqual(150);
+    for (const age of [-100, 0, 60, 119, 1000]) {
+      for (const lifeTable of ["world", "us"]) {
+        const value = estimateExpectancy(age, "female", lifeTable);
+        expect(value).toBeGreaterThanOrEqual(1);
+        expect(value).toBeLessThanOrEqual(150);
+      }
     }
   });
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -222,6 +222,7 @@ describe("save / load with the localStorage fallback", () => {
       expectancy: 80,
       expectancySource: "estimate",
       sex: null,
+      lifeTable: "world",
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -237,6 +238,7 @@ describe("save / load with the localStorage fallback", () => {
       expectancy: 70,
       expectancySource: "custom",
       sex: "female",
+      lifeTable: "us",
       mode: "days",
       typeface: "mono",
       reflection: true,
@@ -257,6 +259,7 @@ describe("save / load with the localStorage fallback", () => {
       // "custom" so its flat number never silently changes on update.
       expectancySource: "custom",
       sex: null,
+      lifeTable: "world",
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -302,6 +305,7 @@ describe("save / load with the localStorage fallback", () => {
       expectancy: 80,
       expectancySource: "estimate",
       sex: null,
+      lifeTable: "world",
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -327,6 +331,7 @@ describe("save / load with the localStorage fallback", () => {
       expectancy: 80,
       expectancySource: "estimate",
       sex: null,
+      lifeTable: "world",
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -339,6 +344,7 @@ describe("expectancy-source migration", () => {
     const result = await load();
     expect(result.expectancySource).toBe("estimate");
     expect(result.sex).toBe(null);
+    expect(result.lifeTable).toBe("world");
   });
 
   it("pins a pre-existing record without a source to custom", async () => {
@@ -348,6 +354,7 @@ describe("expectancy-source migration", () => {
     expect(result.expectancySource).toBe("custom");
     expect(result.expectancy).toBe(66);
     expect(result.sex).toBe(null);
+    expect(result.lifeTable).toBe("world");
   });
 
   it("preserves an explicit estimate source on an existing record", async () => {
@@ -356,10 +363,12 @@ describe("expectancy-source migration", () => {
       birthZone: "UTC",
       expectancySource: "estimate",
       sex: "female",
+      lifeTable: "us",
     });
     const result = await load();
     expect(result.expectancySource).toBe("estimate");
     expect(result.sex).toBe("female");
+    expect(result.lifeTable).toBe("us");
   });
 
   it("migrates the legacy dob record to a custom source", async () => {
@@ -367,6 +376,7 @@ describe("expectancy-source migration", () => {
     const result = await load();
     expect(result.expectancySource).toBe("custom");
     expect(result.sex).toBe(null);
+    expect(result.lifeTable).toBe("world");
   });
 
   it("persists the migration so it stays stable on the next load", async () => {
@@ -375,6 +385,28 @@ describe("expectancy-source migration", () => {
     const persisted = JSON.parse(localStorage.getItem("mortality"));
     expect(persisted.expectancySource).toBe("custom");
     expect(persisted.sex).toBe(null);
+    expect(persisted.lifeTable).toBe("world");
+  });
+
+  it("normalizes an unknown stored life table to World", async () => {
+    await save({
+      birth: "1980-01-01T00:00",
+      birthZone: "UTC",
+      expectancySource: "estimate",
+      lifeTable: "timezone-derived",
+    });
+    const result = await load();
+    expect(result.lifeTable).toBe("world");
+  });
+
+  it("never infers an actuarial baseline from the birth time zone", async () => {
+    await save({
+      birth: "1980-01-01T00:00",
+      birthZone: "America/New_York",
+      expectancySource: "estimate",
+    });
+    const result = await load();
+    expect(result.lifeTable).toBe("world");
   });
 });
 
@@ -400,6 +432,29 @@ describe("effectiveExpectancy", () => {
     expect(Number.isInteger(male)).toBe(true);
     expect(male).toBeGreaterThanOrEqual(70); // never below current age
     expect(female).toBeGreaterThanOrEqual(male); // female >= male
+  });
+
+  it("uses the explicitly selected actuarial baseline", () => {
+    const world = effectiveExpectancy(
+      {
+        expectancySource: "estimate",
+        sex: "male",
+        lifeTable: "world",
+        expectancy: 80,
+      },
+      40,
+    );
+    const us = effectiveExpectancy(
+      {
+        expectancySource: "estimate",
+        sex: "male",
+        lifeTable: "us",
+        expectancy: 80,
+      },
+      40,
+    );
+    expect(world).not.toBe(us);
+    expect(us).toBeGreaterThan(world);
   });
 
   it("falls back to the clamped custom value when the age is unavailable", () => {
@@ -468,6 +523,7 @@ describe("save / load against extension storage", () => {
       expectancy: 95,
       expectancySource: "custom",
       sex: null,
+      lifeTable: "world",
       mode: "years",
       typeface: "system",
       reflection: false,
@@ -508,6 +564,7 @@ describe("save / load against extension storage", () => {
       expectancy: 80,
       expectancySource: "estimate",
       sex: null,
+      lifeTable: "world",
       mode: "years",
       typeface: "system",
       reflection: false,

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -100,6 +100,17 @@ describe("setup flow", () => {
     expect(stored().sex).toBe("female");
     // A brand-new setup leaves the actuarial estimate as the active source.
     expect(stored().expectancySource).toBe("estimate");
+    expect(stored().lifeTable).toBe("world");
+  });
+
+  it("persists an explicitly selected U.S. actuarial baseline", async () => {
+    await boot();
+    document.querySelector("#birth-date").value = "1990-06-15";
+    document.querySelector("#birth-life-table").value = "us";
+    document
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(stored().lifeTable).toBe("us");
   });
 });
 
@@ -414,7 +425,7 @@ describe("settings routing and edits", () => {
   });
 });
 
-describe("settings: life-expectancy source and sex", () => {
+describe("settings: life-expectancy source, baseline, and sex", () => {
   const bornMs = new Date("2000-01-01T00:00").getTime();
   const ageYears = (from) => (from - bornMs) / YEAR_MS;
 
@@ -432,6 +443,22 @@ describe("settings: life-expectancy source and sex", () => {
     expect(shown).toBe(expected);
     // A 20-year-old's conditional expectancy differs from the flat at-birth 80.
     expect(shown).not.toBe(80);
+  });
+
+  it("uses the explicitly selected U.S. baseline", async () => {
+    seed({
+      birth: "2000-01-01T00:00",
+      expectancySource: "estimate",
+      lifeTable: "us",
+      sex: "male",
+      mode: "years",
+    });
+    await boot();
+    const expected = estimateExpectancy(ageYears(Date.now()), "male", "us");
+    const shown = Number(
+      document.querySelector("#pct").textContent.match(/of (\d+) yrs lived/)[1],
+    );
+    expect(shown).toBe(expected);
   });
 
   it("reflects the chosen sex in the estimate denominator", async () => {
@@ -496,6 +523,23 @@ describe("settings: life-expectancy source and sex", () => {
     expect(stored().sex).toBe("male");
     // The estimate line re-renders for the new sex.
     expect(document.querySelector("#expectancy-estimate")).not.toBeNull();
+  });
+
+  it("changes the actuarial baseline from settings and persists it", async () => {
+    seed({
+      birth: "2000-01-01T00:00",
+      expectancySource: "estimate",
+      lifeTable: "world",
+      sex: "male",
+    });
+    await boot();
+    document.querySelector("#gear").click();
+    const lifeTable = document.querySelector("#settings-life-table");
+    expect(lifeTable.value).toBe("world");
+    lifeTable.value = "us";
+    lifeTable.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(stored().lifeTable).toBe("us");
+    expect(document.querySelector("#settings-life-table").value).toBe("us");
   });
 });
 

--- a/test/tab.test.js
+++ b/test/tab.test.js
@@ -118,6 +118,7 @@ describe("mergeImported", () => {
     expectancy: 80,
     expectancySource: "estimate",
     sex: null,
+    lifeTable: "world",
     mode: "years",
     typeface: "system",
     reflection: false,
@@ -165,6 +166,16 @@ describe("mergeImported", () => {
     expect(
       mergeImported(current, { expectancySource: "banana" }).expectancySource,
     ).toBe(current.expectancySource);
+  });
+
+  it("accepts known life tables and ignores an unknown one", () => {
+    expect(mergeImported(current, { lifeTable: "us" }).lifeTable).toBe("us");
+    expect(mergeImported(current, { lifeTable: "world" }).lifeTable).toBe(
+      "world",
+    );
+    expect(mergeImported(current, { lifeTable: "timezone" }).lifeTable).toBe(
+      current.lifeTable,
+    );
   });
 
   it("falls back to the system typeface for an unknown value", () => {

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -108,7 +108,7 @@ describe("renderSetup", () => {
       [...lifeTable.options].map(({ textContent }) => textContent),
     ).toEqual(["World — UN 2023", "United States — SSA 2023"]);
     expect(app.querySelector('label[for="birth-life-table"]').textContent).toBe(
-      "Actuarial baseline",
+      "Life expectancy data source",
     );
   });
 
@@ -473,7 +473,7 @@ describe("renderSettings", () => {
     const line = app.querySelector("#expectancy-estimate");
     expect(line).not.toBeNull();
     expect(line.textContent).toContain("84");
-    expect(line.textContent).toContain("actuarial estimate");
+    expect(line.textContent).toContain("based on your age");
   });
 
   it("prompts for a birthday when no estimate is available", () => {
@@ -511,7 +511,7 @@ describe("renderSettings", () => {
     expect(a.setSex).toHaveBeenCalledWith(null);
   });
 
-  it("preselects and reports the actuarial baseline in estimate mode", () => {
+  it("preselects and reports the life-expectancy data source", () => {
     const a = actions();
     renderSettings(
       app,
@@ -519,6 +519,9 @@ describe("renderSettings", () => {
       data({ expectancySource: "estimate", lifeTable: "us" }),
     );
     const lifeTable = app.querySelector("#settings-life-table");
+    expect(
+      app.querySelector('label[for="settings-life-table"]').textContent,
+    ).toBe("Data source");
     expect(lifeTable.value).toBe("us");
     lifeTable.value = "world";
     lifeTable.dispatchEvent(new Event("change", { bubbles: true }));

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -47,7 +47,7 @@ describe("renderSetup", () => {
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2000-03-04T09:15", zone, null);
+    expect(start).toHaveBeenCalledWith("2000-03-04T09:15", zone, null, "world");
   });
 
   it("defaults an empty time to midnight", () => {
@@ -58,7 +58,7 @@ describe("renderSetup", () => {
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2010-10-10T00:00", zone, null);
+    expect(start).toHaveBeenCalledWith("2010-10-10T00:00", zone, null, "world");
   });
 
   it("blocks submission and reports validity when the date is empty", () => {
@@ -79,7 +79,7 @@ describe("renderSetup", () => {
     app.querySelector("#birth-date").value = "1975-12-25";
     const zone = app.querySelector("#birth-zone").value;
     keydown(app.querySelector("#birth-date"), "Enter");
-    expect(start).toHaveBeenCalledWith("1975-12-25T00:00", zone, null);
+    expect(start).toHaveBeenCalledWith("1975-12-25T00:00", zone, null, "world");
   });
 
   it("renders a birthplace time-zone select defaulting to the device zone", () => {
@@ -97,6 +97,24 @@ describe("renderSetup", () => {
   it("pre-selects the saved birth zone when editing", () => {
     renderSetup(app, { start: vi.fn() }, "1990-05-15T00:00", "Asia/Tokyo");
     expect(app.querySelector("#birth-zone").value).toBe("Asia/Tokyo");
+  });
+
+  it("offers an explicit actuarial baseline defaulting to World", () => {
+    renderSetup(app, { start: vi.fn() }, null);
+    const lifeTable = app.querySelector("#birth-life-table");
+    expect(lifeTable).not.toBeNull();
+    expect(lifeTable.value).toBe("world");
+    expect(
+      [...lifeTable.options].map(({ textContent }) => textContent),
+    ).toEqual(["World — UN 2023", "United States — SSA 2023"]);
+    expect(app.querySelector('label[for="birth-life-table"]').textContent).toBe(
+      "Actuarial baseline",
+    );
+  });
+
+  it("pre-selects a saved U.S. baseline when editing", () => {
+    renderSetup(app, { start: vi.fn() }, "1990-05-15T00:00", "UTC", null, "us");
+    expect(app.querySelector("#birth-life-table").value).toBe("us");
   });
 
   it("caps the birth date at today", () => {
@@ -157,7 +175,24 @@ describe("renderSetup", () => {
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("1980-07-08T00:00", zone, "male");
+    expect(start).toHaveBeenCalledWith(
+      "1980-07-08T00:00",
+      zone,
+      "male",
+      "world",
+    );
+  });
+
+  it("passes the chosen actuarial baseline through to start", () => {
+    const start = vi.fn();
+    renderSetup(app, { start }, null);
+    app.querySelector("#birth-date").value = "1980-07-08";
+    app.querySelector("#birth-life-table").value = "us";
+    const zone = app.querySelector("#birth-zone").value;
+    app
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(start).toHaveBeenCalledWith("1980-07-08T00:00", zone, null, "us");
   });
 });
 
@@ -227,6 +262,7 @@ describe("renderSettings", () => {
     setExpectancy: vi.fn(),
     setExpectancySource: vi.fn(),
     setSex: vi.fn(),
+    setLifeTable: vi.fn(),
     resetColors: vi.fn(),
     resetBirthday: vi.fn(),
     closeSettings: vi.fn(),
@@ -242,6 +278,7 @@ describe("renderSettings", () => {
     expectancy: 80,
     expectancySource: "custom",
     sex: null,
+    lifeTable: "world",
     estimate: 84,
     typeface: "system",
     reflection: false,
@@ -422,6 +459,8 @@ describe("renderSettings", () => {
     renderSettings(app, actions(), data({ expectancySource: "custom" }));
     expect(app.querySelector("#expectancy")).not.toBeNull();
     expect(app.querySelector("#expectancy-estimate")).toBeNull();
+    expect(app.querySelector("#settings-life-table")).toBeNull();
+    expect(app.querySelector("#settings-sex")).toBeNull();
   });
 
   it("hides the Years input and previews the estimate in estimate mode", () => {
@@ -457,7 +496,11 @@ describe("renderSettings", () => {
 
   it("preselects the stored sex and reports changes, mapping blank to null", () => {
     const a = actions();
-    renderSettings(app, a, data({ sex: "female" }));
+    renderSettings(
+      app,
+      a,
+      data({ expectancySource: "estimate", sex: "female" }),
+    );
     const sex = app.querySelector("#settings-sex");
     expect(sex.value).toBe("female");
     sex.value = "male";
@@ -466,5 +509,19 @@ describe("renderSettings", () => {
     sex.value = "";
     sex.dispatchEvent(new Event("change", { bubbles: true }));
     expect(a.setSex).toHaveBeenCalledWith(null);
+  });
+
+  it("preselects and reports the actuarial baseline in estimate mode", () => {
+    const a = actions();
+    renderSettings(
+      app,
+      a,
+      data({ expectancySource: "estimate", lifeTable: "us" }),
+    );
+    const lifeTable = app.querySelector("#settings-life-table");
+    expect(lifeTable.value).toBe("us");
+    lifeTable.value = "world";
+    lifeTable.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(a.setLifeTable).toHaveBeenCalledWith("world");
   });
 });


### PR DESCRIPTION
## Summary

- Make the World aggregate from UN World Population Prospects 2024 (year 2023) the default actuarial baseline.
- Keep the U.S. SSA 2023 Period Life Table as an explicit alternative and preserve the fully custom whole-year override.
- Let users choose World or United States during setup and in Settings; the choice is never inferred from birthday or system time zone.
- Use the official UN both-sexes series when sex at birth is not shared, with the existing optional female/male refinement.
- Include packaged UN attribution/licensing and SSA public-domain notices.

## Compatibility

Existing released records still migrate to Custom so their saved expectancy does not change. Records created by the actuarial feature that lack a baseline migrate to World. Imports accept only known baseline IDs.

## Data sources

- United Nations, *World Population Prospects 2024*, World aggregate, 2023 Medium variant: https://population.un.org/wpp/ (CC BY 3.0 IGO)
- U.S. Social Security Administration, *Period Life Table 2023*: https://www.ssa.gov/oact/STATS/table4c6.html (U.S. federal-government public domain)

## Validation

- 226 tests pass
- Prettier format check passes
- All changed source modules pass `node --check`
- Packaged ZIP includes `lifetable.js` and `THIRD_PARTY_NOTICES.txt`

Please review; do not merge automatically.