### PR TITLE
Add manual language selection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -248,7 +248,7 @@ never a bounce, never a glow-for-flavor.
 ### Inputs / Fields
 
 - **Style:** `1px` hairline border, canvas/field background, `0.25rem` radius. Date, time,
-  number, and color inputs share one vocabulary. `appearance: none`.
+  number, color, and language inputs share one vocabulary. `appearance: none`.
 - **Focus:** `2px solid` focus tone, `2px` offset.
 
 ### Preset Swatch

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ A browser extension that replaces your new tab page with a live counter of your 
   explicitly selected World (UN 2023) or United States (SSA 2023) baseline.
 - **Personalization** — light and dark themes that follow your system, color presets
   and custom colors, plus a fully custom life expectancy.
-- **Automatic localization** — follows your browser language across all 55 official
-  Chrome WebExtension locales.
+- **Language choice** — follows your browser by default, with a manual choice from all
+  55 official Chrome WebExtension locales.
 - **Accessible and calm** — WCAG 2.1 AA, a `prefers-reduced-motion` path, and full
   keyboard support.
 
 ## Languages
 
-Mortality follows the browser/OS locale automatically and falls back to English; no
-in-extension language setting is needed. It ships every
+Mortality follows the browser/OS locale by default and falls back to English. You can
+choose a different language during setup or later under **Settings → Display**. It ships
+every
 [Chrome-supported extension locale](https://developer.chrome.com/docs/extensions/reference/api/i18n#locales):
 `ar`, `am`, `bg`, `bn`, `ca`, `cs`, `da`, `de`, `el`, `en`, `en_AU`, `en_GB`,
 `en_US`, `es`, `es_419`, `et`, `fa`, `fi`, `fil`, `fr`, `gu`, `he`, `hi`, `hr`,

--- a/src/_locales/am/messages.json
+++ b/src/_locales/am/messages.json
@@ -241,6 +241,14 @@
     "message": "ማሳያ",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "ቋንቋ",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "የአሳሹ ነባሪ",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "አህዞች",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -241,6 +241,14 @@
     "message": "العرض",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "اللغة",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "لغة المتصفح الافتراضية",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "الأرقام",
     "description": "Numeral typeface setting label."

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -241,6 +241,14 @@
     "message": "Изглед",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Език",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "По подразбиране на браузъра",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Цифри",
     "description": "Numeral typeface setting label."

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -241,6 +241,14 @@
     "message": "প্রদর্শন",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "ভাষা",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ব্রাউজারের ডিফল্ট",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "অঙ্ক",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -241,6 +241,14 @@
     "message": "Visualització",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Idioma",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Valor predeterminat del navegador",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Xifres",
     "description": "Numeral typeface setting label."

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -241,6 +241,14 @@
     "message": "Zobrazení",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Jazyk",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Výchozí nastavení prohlížeče",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Číslice",
     "description": "Numeral typeface setting label."

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -241,6 +241,14 @@
     "message": "Visning",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Sprog",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Browserens standard",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Cifre",
     "description": "Numeral typeface setting label."

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -241,6 +241,14 @@
     "message": "Anzeige",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Sprache",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Browserstandard",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Ziffern",
     "description": "Numeral typeface setting label."

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -241,6 +241,14 @@
     "message": "Προβολή",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Γλώσσα",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Προεπιλογή προγράμματος περιήγησης",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Ψηφία",
     "description": "Numeral typeface setting label."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -214,6 +214,14 @@
     "message": "Display",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Language",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Browser default",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerals",
     "description": "Numeral typeface setting label."

--- a/src/_locales/en_AU/messages.json
+++ b/src/_locales/en_AU/messages.json
@@ -241,6 +241,14 @@
     "message": "Display",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Language",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Browser default",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerals",
     "description": "Numeral typeface setting label."

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -241,6 +241,14 @@
     "message": "Display",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Language",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Browser default",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerals",
     "description": "Numeral typeface setting label."

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -241,6 +241,14 @@
     "message": "Display",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Language",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Browser default",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerals",
     "description": "Numeral typeface setting label."

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -241,6 +241,14 @@
     "message": "Pantalla",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Idioma",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Predeterminado del navegador",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerales",
     "description": "Numeral typeface setting label."

--- a/src/_locales/es_419/messages.json
+++ b/src/_locales/es_419/messages.json
@@ -241,6 +241,14 @@
     "message": "Pantalla",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Idioma",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Predeterminado del navegador",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerales",
     "description": "Numeral typeface setting label."

--- a/src/_locales/et/messages.json
+++ b/src/_locales/et/messages.json
@@ -241,6 +241,14 @@
     "message": "Kuvamine",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Keel",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Brauseri vaikeväärtus",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numbrid",
     "description": "Numeral typeface setting label."

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -241,6 +241,14 @@
     "message": "نمایش",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "زبان",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "پیش‌فرض مرورگر",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "ارقام",
     "description": "Numeral typeface setting label."

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -241,6 +241,14 @@
     "message": "Näyttö",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Kieli",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Selaimen oletus",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerot",
     "description": "Numeral typeface setting label."

--- a/src/_locales/fil/messages.json
+++ b/src/_locales/fil/messages.json
@@ -241,6 +241,14 @@
     "message": "Display",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Wika",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Default ng browser",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Mga Numero",
     "description": "Numeral typeface setting label."

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -241,6 +241,14 @@
     "message": "Affichage",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Langue",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Langue du navigateur",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Chiffres",
     "description": "Numeral typeface setting label."

--- a/src/_locales/gu/messages.json
+++ b/src/_locales/gu/messages.json
@@ -241,6 +241,14 @@
     "message": "ડિસ્પ્લે",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "ભાષા",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "બ્રાઉઝર ડિફૉલ્ટ",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "આંકડા",
     "description": "Numeral typeface setting label."

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -241,6 +241,14 @@
     "message": "תצוגה",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "שפה",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ברירת המחדל של הדפדפן",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "ספרות",
     "description": "Numeral typeface setting label."

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -241,6 +241,14 @@
     "message": "प्रदर्शन",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "भाषा",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ब्राउज़र डिफ़ॉल्ट",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "अंक",
     "description": "Numeral typeface setting label."

--- a/src/_locales/hr/messages.json
+++ b/src/_locales/hr/messages.json
@@ -241,6 +241,14 @@
     "message": "Prikaz",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Jezik",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Zadano u pregledniku",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Znamenke",
     "description": "Numeral typeface setting label."

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -241,6 +241,14 @@
     "message": "Megjelenítés",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Nyelv",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Böngésző alapértelmezése",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Számjegyek",
     "description": "Numeral typeface setting label."

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -241,6 +241,14 @@
     "message": "Tampilan",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Bahasa",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Default browser",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Angka",
     "description": "Numeral typeface setting label."

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -241,6 +241,14 @@
     "message": "Visualizzazione",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Lingua",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Predefinita del browser",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numeri",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -241,6 +241,14 @@
     "message": "表示",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "言語",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ブラウザーの既定",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "数字",
     "description": "Numeral typeface setting label."

--- a/src/_locales/kn/messages.json
+++ b/src/_locales/kn/messages.json
@@ -241,6 +241,14 @@
     "message": "ಪ್ರದರ್ಶನ",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "ಭಾಷೆ",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ಬ್ರೌಸರ್ ಡೀಫಾಲ್ಟ್",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "ಅಂಕೆಗಳು",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -241,6 +241,14 @@
     "message": "표시",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "언어",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "브라우저 기본값",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "숫자",
     "description": "Numeral typeface setting label."

--- a/src/_locales/lt/messages.json
+++ b/src/_locales/lt/messages.json
@@ -241,6 +241,14 @@
     "message": "Rodymas",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Kalba",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Numatytoji naršyklės kalba",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Skaitmenys",
     "description": "Numeral typeface setting label."

--- a/src/_locales/lv/messages.json
+++ b/src/_locales/lv/messages.json
@@ -241,6 +241,14 @@
     "message": "Attēlošana",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Valoda",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Pārlūka noklusējums",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Cipari",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -241,6 +241,14 @@
     "message": "പ്രദർശനം",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "ഭാഷ",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ബ്രൗസറിന്റെ ഡിഫോൾട്ട്",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "അക്കങ്ങൾ",
     "description": "Numeral typeface setting label."

--- a/src/_locales/mr/messages.json
+++ b/src/_locales/mr/messages.json
@@ -241,6 +241,14 @@
     "message": "प्रदर्शन",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "भाषा",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ब्राउझर डीफॉल्ट",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "अंक",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ms/messages.json
+++ b/src/_locales/ms/messages.json
@@ -241,6 +241,14 @@
     "message": "Paparan",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Bahasa",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Lalai penyemak imbas",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Nombor",
     "description": "Numeral typeface setting label."

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -241,6 +241,14 @@
     "message": "Weergave",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Taal",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Browserstandaard",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Cijfers",
     "description": "Numeral typeface setting label."

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -241,6 +241,14 @@
     "message": "Visning",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Språk",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Nettleserstandard",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Siffer",
     "description": "Numeral typeface setting label."

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -241,6 +241,14 @@
     "message": "Wyświetlanie",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Język",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Domyślny język przeglądarki",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Cyfry",
     "description": "Numeral typeface setting label."

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -241,6 +241,14 @@
     "message": "Exibição",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Idioma",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Padrão do navegador",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerais",
     "description": "Numeral typeface setting label."

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -241,6 +241,14 @@
     "message": "Visualização",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Idioma",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Predefinição do navegador",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Numerais",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -241,6 +241,14 @@
     "message": "Afișare",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Limbă",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Implicit al browserului",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Cifre",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -241,6 +241,14 @@
     "message": "Отображение",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Язык",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "По умолчанию в браузере",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Цифры",
     "description": "Numeral typeface setting label."

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -241,6 +241,14 @@
     "message": "Zobrazenie",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Jazyk",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Predvolené nastavenie prehliadača",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Číslice",
     "description": "Numeral typeface setting label."

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -241,6 +241,14 @@
     "message": "Prikaz",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Jezik",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Privzeto v brskalniku",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Številke",
     "description": "Numeral typeface setting label."

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -241,6 +241,14 @@
     "message": "Приказ",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Језик",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Подразумевано у прегледачу",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Цифре",
     "description": "Numeral typeface setting label."

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -241,6 +241,14 @@
     "message": "Visning",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Språk",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Webbläsarens standard",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Siffror",
     "description": "Numeral typeface setting label."

--- a/src/_locales/sw/messages.json
+++ b/src/_locales/sw/messages.json
@@ -241,6 +241,14 @@
     "message": "Onyesho",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Lugha",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Chaguo-msingi la kivinjari",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Nambari",
     "description": "Numeral typeface setting label."

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -241,6 +241,14 @@
     "message": "காட்சி",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "மொழி",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "உலாவியின் இயல்புநிலை",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "எண்கள்",
     "description": "Numeral typeface setting label."

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -241,6 +241,14 @@
     "message": "ప్రదర్శన",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "భాష",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "బ్రౌజర్ డిఫాల్ట్",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "సంఖ్యలు",
     "description": "Numeral typeface setting label."

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -241,6 +241,14 @@
     "message": "การแสดงผล",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "ภาษา",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "ค่าเริ่มต้นของเบราว์เซอร์",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "ตัวเลข",
     "description": "Numeral typeface setting label."

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -241,6 +241,14 @@
     "message": "Görünüm",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Dil",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Tarayıcı varsayılanı",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Rakamlar",
     "description": "Numeral typeface setting label."

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -241,6 +241,14 @@
     "message": "Відображення",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Мова",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "За замовчуванням у браузері",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Цифри",
     "description": "Numeral typeface setting label."

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -241,6 +241,14 @@
     "message": "Hiển thị",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "Ngôn ngữ",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "Mặc định của trình duyệt",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "Chữ số",
     "description": "Numeral typeface setting label."

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -241,6 +241,14 @@
     "message": "显示",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "语言",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "浏览器默认",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "数字",
     "description": "Numeral typeface setting label."

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -241,6 +241,14 @@
     "message": "顯示",
     "description": "Settings section heading."
   },
+  "language": {
+    "message": "語言",
+    "description": "Language setting label."
+  },
+  "languageAutomatic": {
+    "message": "瀏覽器預設",
+    "description": "Option that follows the browser's language."
+  },
   "numerals": {
     "message": "數字",
     "description": "Numeral typeface setting label."

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -54,6 +54,8 @@ export const EN_MESSAGES = {
   colorCounter: "Counter",
   colorAccent: "Accent",
   sectionDisplay: "Display",
+  language: "Language",
+  languageAutomatic: "Browser default",
   numerals: "Numerals",
   typefaceSystem: "System",
   typefaceGrotesk: "Grotesk",
@@ -105,16 +107,87 @@ const PLACEHOLDERS = {
   weeksSummary: { LIVED: 0, AHEAD: 1, YEARS: 2 },
 };
 
+export const AUTOMATIC_LANGUAGE = "auto";
+
+// Chrome's complete supported WebExtension locale set. Locale catalogs use
+// underscores on disk, while Intl expects BCP 47 hyphens.
+export const SUPPORTED_LANGUAGES = [
+  "am",
+  "ar",
+  "bg",
+  "bn",
+  "ca",
+  "cs",
+  "da",
+  "de",
+  "el",
+  "en",
+  "en_AU",
+  "en_GB",
+  "en_US",
+  "es",
+  "es_419",
+  "et",
+  "fa",
+  "fi",
+  "fil",
+  "fr",
+  "gu",
+  "he",
+  "hi",
+  "hr",
+  "hu",
+  "id",
+  "it",
+  "ja",
+  "kn",
+  "ko",
+  "lt",
+  "lv",
+  "ml",
+  "mr",
+  "ms",
+  "nl",
+  "no",
+  "pl",
+  "pt_BR",
+  "pt_PT",
+  "ro",
+  "ru",
+  "sk",
+  "sl",
+  "sr",
+  "sv",
+  "sw",
+  "ta",
+  "te",
+  "th",
+  "tr",
+  "uk",
+  "vi",
+  "zh_CN",
+  "zh_TW",
+];
+
+let activeLocale = null;
+let activeCatalog = null;
+let activationRequest = 0;
+const catalogCache = new Map();
+
 function extensionI18n() {
   return globalThis.browser?.i18n ?? globalThis.chrome?.i18n ?? null;
 }
 
-function substituteFallback(key, substitutions) {
-  const values = Array.isArray(substitutions)
+function substitutionValues(substitutions) {
+  return Array.isArray(substitutions)
     ? substitutions
     : substitutions == null
       ? []
       : [substitutions];
+}
+
+function substituteFallback(key, substitutions) {
+  const values = substitutionValues(substitutions);
   const placeholders = PLACEHOLDERS[key] ?? {};
   return EN_MESSAGES[key].replace(/\$([A-Z][A-Z0-9_]*)\$/g, (token, name) => {
     const index = placeholders[name];
@@ -122,7 +195,25 @@ function substituteFallback(key, substitutions) {
   });
 }
 
+function substituteCatalog(entry, substitutions) {
+  const values = substitutionValues(substitutions);
+  const placeholders = entry.placeholders ?? {};
+  return entry.message.replace(
+    /\$([A-Z][A-Z0-9_]*)\$/gi,
+    (token, placeholderName) => {
+      const content = placeholders[placeholderName.toLowerCase()]?.content;
+      const match = typeof content === "string" && content.match(/^\$(\d+)$/);
+      return match ? String(values[Number(match[1]) - 1] ?? "") : token;
+    },
+  );
+}
+
 export function msg(key, substitutions) {
+  if (activeCatalog) {
+    const entry = activeCatalog[key];
+    if (entry?.message) return substituteCatalog(entry, substitutions);
+    return EN_MESSAGES[key] ? substituteFallback(key, substitutions) : "";
+  }
   const api = extensionI18n();
   if (api?.getMessage) {
     const localized = api.getMessage(key, substitutions);
@@ -131,16 +222,96 @@ export function msg(key, substitutions) {
   return EN_MESSAGES[key] ? substituteFallback(key, substitutions) : "";
 }
 
-function validLocale(value) {
-  const normalized = String(value || "en").replaceAll("_", "-");
+function canonicalLocale(value) {
+  const normalized = String(value || "").replaceAll("_", "-");
   try {
-    return Intl.getCanonicalLocales(normalized)[0] || "en";
+    return Intl.getCanonicalLocales(normalized)[0] || null;
   } catch {
-    return "en";
+    return null;
   }
 }
 
+function validLocale(value) {
+  return canonicalLocale(value) || "en";
+}
+
+const LANGUAGE_BY_LOCALE = new Map(
+  SUPPORTED_LANGUAGES.map((language) => [
+    validLocale(language).toLowerCase(),
+    language,
+  ]),
+);
+
+export function normalizeLanguage(value) {
+  if (!value || value === AUTOMATIC_LANGUAGE) return AUTOMATIC_LANGUAGE;
+  const locale = canonicalLocale(value);
+  return locale
+    ? LANGUAGE_BY_LOCALE.get(locale.toLowerCase()) || AUTOMATIC_LANGUAGE
+    : AUTOMATIC_LANGUAGE;
+}
+
+export function languageName(language) {
+  const locale = validLocale(language);
+  try {
+    return (
+      new Intl.DisplayNames([locale], { type: "language" }).of(locale) || locale
+    );
+  } catch {
+    return locale;
+  }
+}
+
+async function loadCatalog(language) {
+  if (!catalogCache.has(language)) {
+    catalogCache.set(
+      language,
+      (async () => {
+        const response = await fetch(
+          new URL(`./_locales/${language}/messages.json`, import.meta.url),
+        );
+        if (!response.ok) {
+          throw new Error(
+            `Could not load ${language} translations (${response.status})`,
+          );
+        }
+        const catalog = await response.json();
+        if (!catalog || typeof catalog !== "object" || Array.isArray(catalog)) {
+          throw new TypeError(`Invalid ${language} translation catalog`);
+        }
+        return catalog;
+      })(),
+    );
+  }
+  try {
+    return await catalogCache.get(language);
+  } catch (error) {
+    catalogCache.delete(language);
+    throw error;
+  }
+}
+
+/**
+ * Activate a bundled locale, or return to the browser's locale with "auto".
+ * Returns null when a newer activation supersedes this request.
+ */
+export async function activateLanguage(value) {
+  const request = ++activationRequest;
+  const language = normalizeLanguage(value);
+  if (language === AUTOMATIC_LANGUAGE) {
+    activeLocale = null;
+    activeCatalog = null;
+    return language;
+  }
+
+  const catalog = await loadCatalog(language);
+  if (request !== activationRequest) return null;
+  activeLocale = validLocale(language);
+  activeCatalog = catalog;
+  return language;
+}
+
 export function getLocale() {
+  if (activeLocale) return activeLocale;
   const api = extensionI18n();
   let locale = api?.getUILanguage?.() || api?.getMessage?.("@@ui_locale");
   if (!locale) locale = globalThis.navigator?.language || "en";
@@ -148,6 +319,9 @@ export function getLocale() {
 }
 
 export function getDirection() {
+  if (activeLocale) {
+    return /^(ar|fa|he)(-|$)/i.test(activeLocale) ? "rtl" : "ltr";
+  }
   const apiDirection = extensionI18n()?.getMessage?.("@@bidi_dir");
   if (apiDirection === "rtl" || apiDirection === "ltr") return apiDirection;
   return /^(ar|fa|he)(-|$)/i.test(getLocale()) ? "rtl" : "ltr";

--- a/src/store.js
+++ b/src/store.js
@@ -90,6 +90,7 @@ const DEFAULTS = {
   mode: "years",
   typeface: "system",
   reflection: false,
+  language: "auto",
 };
 
 /**
@@ -235,7 +236,7 @@ function migrateExpectancy(state, raw) {
  * forward without changing the age shown today. Records that predate the
  * actuarial-expectancy feature keep their flat number by being pinned to a
  * "custom" expectancy source (see migrateExpectancy).
- * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, expectancySource: string, sex: string|null, lifeTable: string, mode: string, typeface: string, reflection: boolean }>}
+ * @returns {Promise<{ version: number, birth: string|null, birthZone: string|null, theme: Record<string,string>|null, expectancy: number, expectancySource: string, sex: string|null, lifeTable: string, mode: string, typeface: string, reflection: boolean, language: string }>}
  */
 export async function load() {
   let stored;

--- a/src/tab.css
+++ b/src/tab.css
@@ -364,6 +364,12 @@ footer {
   text-align: start;
 }
 
+.setup-language {
+  width: min(22rem, 100%);
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+}
+
 .setup-label {
   color: var(--label);
   font-size: 0.72rem;

--- a/src/tab.js
+++ b/src/tab.js
@@ -35,6 +35,8 @@ import {
 } from "./lifetable.js";
 import { el } from "./dom.js";
 import {
+  AUTOMATIC_LANGUAGE,
+  activateLanguage,
   applyDocumentLocale,
   formatDate,
   formatFixedParts,
@@ -44,6 +46,7 @@ import {
   formatUnit,
   formatUnitParts,
   msg,
+  normalizeLanguage,
 } from "./i18n.js";
 
 const YEAR_MS = 31556900000; // milliseconds per year (preserved from v1.2)
@@ -61,7 +64,6 @@ const LABELS = {
   weeksLeft: "modeWeeksLeft",
 };
 
-applyDocumentLocale();
 const app = document.getElementById("app");
 let state;
 let timer = null;
@@ -196,19 +198,60 @@ export function mergeImported(current, imported) {
   if ("typeface" in src)
     known.typeface = TYPEFACES.includes(src.typeface) ? src.typeface : "system";
   if ("reflection" in src) known.reflection = Boolean(src.reflection);
+  if ("language" in src) known.language = normalizeLanguage(src.language);
   return { ...current, ...known };
 }
 
-function showSetup() {
+async function changeLanguage(value, afterChange) {
+  const language = normalizeLanguage(value);
+  try {
+    const activated = await activateLanguage(language);
+    if (!activated) return;
+  } catch (error) {
+    console.error(`Mortality: could not load the ${language} language`, error);
+    afterChange();
+    return;
+  }
+  state.language = language;
+  save(state);
+  applyDocumentLocale();
+  afterChange();
+}
+
+async function activateStateLanguage() {
+  const language = normalizeLanguage(state.language);
+  try {
+    const activated = await activateLanguage(language);
+    if (!activated) return;
+    state.language = language;
+  } catch (error) {
+    console.error(`Mortality: could not load the ${language} language`, error);
+    state.language = AUTOMATIC_LANGUAGE;
+    await activateLanguage(AUTOMATIC_LANGUAGE);
+  }
+  applyDocumentLocale();
+}
+
+function showSetup(draft = null) {
   stopTimer();
   setScreen("setup");
+  const value = (key) =>
+    draft && Object.prototype.hasOwnProperty.call(draft, key)
+      ? draft[key]
+      : state[key];
   renderSetup(
     app,
-    { start },
-    state.birth,
-    state.birthZone,
-    state.sex,
-    state.lifeTable,
+    {
+      start,
+      setLanguage(language, nextDraft) {
+        changeLanguage(language, () => showSetup(nextDraft));
+      },
+    },
+    value("birth"),
+    value("birthZone"),
+    value("sex"),
+    value("lifeTable"),
+    state.language,
   );
 }
 
@@ -517,6 +560,9 @@ function showSettings() {
         state.birthZone = value;
         save(state);
       },
+      setLanguage(value) {
+        changeLanguage(value, showSettings);
+      },
       exportData() {
         const blob = new Blob([JSON.stringify(state, null, 2)], {
           type: "application/json",
@@ -548,6 +594,7 @@ function showSettings() {
             return;
           }
           state = mergeImported(state, parsed);
+          await activateStateLanguage();
           save(state);
           applyTheme(state.theme);
           applyTypeface(state.typeface);
@@ -572,6 +619,7 @@ function showSettings() {
       typeface: state.typeface,
       reflection: state.reflection,
       birthZone: state.birthZone,
+      language: state.language,
     },
   );
 }
@@ -742,6 +790,7 @@ function updateAmbient() {
 
 async function init() {
   state = await load();
+  await activateStateLanguage();
   applyTheme(state.theme);
   applyTypeface(state.typeface);
 

--- a/src/views.js
+++ b/src/views.js
@@ -15,7 +15,14 @@ import {
   normalizeLifeTable,
 } from "./lifetable.js";
 import { el } from "./dom.js";
-import { formatNumber, msg } from "./i18n.js";
+import {
+  AUTOMATIC_LANGUAGE,
+  SUPPORTED_LANGUAGES,
+  formatNumber,
+  languageName,
+  msg,
+  normalizeLanguage,
+} from "./i18n.js";
 
 const COLOR_LABELS = {
   bg: "colorBackground",
@@ -124,6 +131,27 @@ function lifeTableSelect(id, current) {
   return select;
 }
 
+/** A language picker whose choices identify themselves in their own language. */
+function languageSelect(id, current) {
+  const select = el("select", { id }, [
+    el("option", { value: AUTOMATIC_LANGUAGE }, msg("languageAutomatic")),
+    ...SUPPORTED_LANGUAGES.map((language) => {
+      const locale = language.replaceAll("_", "-");
+      return el(
+        "option",
+        {
+          value: language,
+          lang: locale,
+          dir: /^(ar|fa|he)(-|$)/i.test(locale) ? "rtl" : "ltr",
+        },
+        languageName(language),
+      );
+    }),
+  ]);
+  select.value = normalizeLanguage(current);
+  return select;
+}
+
 /** Today as YYYY-MM-DD in local time, used to cap the birth-date field. */
 function todayISO() {
   const now = new Date();
@@ -141,11 +169,12 @@ function splitBirth(value) {
 /** Birthday entry screen. Stored values pre-fill when editing. */
 export function renderSetup(
   app,
-  { start },
+  { start, setLanguage },
   current,
   savedZone,
   savedSex,
   savedLifeTable,
+  savedLanguage,
 ) {
   const dateEl = el("input", {
     type: "date",
@@ -172,6 +201,7 @@ export function renderSetup(
   zoneEl.value = selectedZone;
   const sexEl = sexSelect("birth-sex", savedSex);
   const lifeTableEl = lifeTableSelect("birth-life-table", savedLifeTable);
+  const languageEl = languageSelect("setup-language", savedLanguage);
   const startBtn = el("button", { id: "start" }, msg("start"));
   const errorEl = el("p", {
     class: "field-error",
@@ -182,6 +212,14 @@ export function renderSetup(
   const form = el("form", {}, [
     el("h1", { class: "screen-title" }, msg("setupTitle")),
     el("p", { class: "screen-subtitle" }, msg("setupSubtitle")),
+    el("div", { class: "setup-field setup-language" }, [
+      el(
+        "label",
+        { class: "setup-label", for: "setup-language" },
+        msg("language"),
+      ),
+      languageEl,
+    ]),
     el("div", { class: "setup-row" }, [dateEl, timeEl]),
     errorEl,
     el("p", { class: "hint setup-hint" }, msg("timeHint")),
@@ -245,6 +283,17 @@ export function renderSetup(
       errorEl.hidden = true;
     }),
   );
+  languageEl.addEventListener("change", () => {
+    const birth = dateEl.value
+      ? `${dateEl.value}T${timeEl.value || "00:00"}`
+      : null;
+    setLanguage(languageEl.value, {
+      birth,
+      birthZone: zoneEl.value,
+      sex: sexEl.value || null,
+      lifeTable: lifeTableEl.value,
+    });
+  });
   [dateEl, timeEl, zoneEl, lifeTableEl, sexEl].forEach((input) =>
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
@@ -356,10 +405,15 @@ export function renderSettings(
     typeface,
     reflection,
     birthZone,
+    language,
   },
 ) {
   const colorInputs = {};
   const notes = {};
+  const languageEl = languageSelect("settings-language", language);
+  languageEl.addEventListener("change", () =>
+    actions.setLanguage(languageEl.value),
+  );
   const rows = THEME_KEYS.flatMap((key) => {
     const attrs = {
       type: "color",
@@ -546,6 +600,10 @@ export function renderSettings(
     el("p", { class: "settings-label" }, msg("sectionColors")),
     ...rows,
     el("p", { class: "settings-label" }, msg("sectionDisplay")),
+    el("div", { class: "row" }, [
+      el("label", { for: "settings-language" }, msg("language")),
+      languageEl,
+    ]),
     el("div", { class: "row" }, [numeralsLabel, typefaceSegment]),
     el("div", { class: "row" }, [
       el("label", { for: "reflection-switch" }, msg("reflectionToggle")),

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -3,7 +3,10 @@ import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  AUTOMATIC_LANGUAGE,
   EN_MESSAGES,
+  SUPPORTED_LANGUAGES,
+  activateLanguage,
   applyDocumentLocale,
   formatDate,
   formatFixedParts,
@@ -14,7 +17,9 @@ import {
   formatUnitParts,
   getDirection,
   getLocale,
+  languageName,
   msg,
+  normalizeLanguage,
 } from "../src/i18n.js";
 import { renderSetup } from "../src/views.js";
 import { formatBorn } from "../src/tab.js";
@@ -111,7 +116,8 @@ function mockLocale(locale, messages = {}) {
   });
 }
 
-afterEach(() => {
+afterEach(async () => {
+  await activateLanguage(AUTOMATIC_LANGUAGE);
   vi.unstubAllGlobals();
   document.documentElement.lang = "en";
   document.documentElement.removeAttribute("dir");
@@ -125,6 +131,7 @@ describe("locale catalogs", () => {
   it("ships exactly the 55 official Chrome WebExtension locales", () => {
     const actual = readdirSync(join(ROOT, "src", "_locales")).sort();
     expect(actual).toEqual([...LOCALES].sort());
+    expect([...SUPPORTED_LANGUAGES].sort()).toEqual([...LOCALES].sort());
   });
 
   it.each(LOCALES)(
@@ -283,6 +290,69 @@ describe("message lookup and document locale", () => {
     mockLocale("en");
     chrome.i18n.getMessage = (key) => (key === "@@bidi_dir" ? "rtl" : "");
     expect(getDirection()).toBe("rtl");
+  });
+
+  it("normalizes supported language choices and rejects unknown values", () => {
+    expect(normalizeLanguage("pt-BR")).toBe("pt_BR");
+    expect(normalizeLanguage("zh_CN")).toBe("zh_CN");
+    expect(normalizeLanguage("not-a-locale")).toBe(AUTOMATIC_LANGUAGE);
+    expect(normalizeLanguage(null)).toBe(AUTOMATIC_LANGUAGE);
+  });
+
+  it("provides a readable native name for every language choice", () => {
+    for (const language of SUPPORTED_LANGUAGES) {
+      expect(languageName(language).trim(), language).not.toBe("");
+    }
+    expect(languageName("de")).toMatch(/Deutsch/i);
+  });
+
+  it("loads a manually selected catalog instead of the browser locale", async () => {
+    mockLocale("en", { settings: "Browser settings" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          settings: { message: "Einstellungen" },
+          progressCaption: {
+            message: "$PERCENT$ von $YEARS$ Jahren gelebt",
+            placeholders: {
+              percent: { content: "$1" },
+              years: { content: "$2" },
+            },
+          },
+        }),
+      })),
+    );
+
+    await expect(activateLanguage("de")).resolves.toBe("de");
+    expect(getLocale()).toBe("de");
+    expect(msg("settings")).toBe("Einstellungen");
+    expect(msg("progressCaption", ["25 %", "80"])).toBe(
+      "25 % von 80 Jahren gelebt",
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: expect.stringContaining("/de/") }),
+    );
+  });
+
+  it("uses the selected language direction instead of the browser direction", async () => {
+    mockLocale("en");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          pageTitle: { message: "Mortality — علامة تبويب جديدة" },
+        }),
+      })),
+    );
+
+    await activateLanguage("ar");
+    applyDocumentLocale();
+    expect(getDirection()).toBe("rtl");
+    expect(document.documentElement.lang).toBe("ar");
+    expect(document.documentElement.dir).toBe("rtl");
   });
 });
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -226,6 +226,7 @@ describe("save / load with the localStorage fallback", () => {
       mode: "years",
       typeface: "system",
       reflection: false,
+      language: "auto",
     });
   });
 
@@ -242,6 +243,7 @@ describe("save / load with the localStorage fallback", () => {
       mode: "days",
       typeface: "mono",
       reflection: true,
+      language: "fr",
     };
     await save(state);
     await expect(load()).resolves.toEqual(state);
@@ -263,6 +265,7 @@ describe("save / load with the localStorage fallback", () => {
       mode: "years",
       typeface: "system",
       reflection: false,
+      language: "auto",
     });
   });
 
@@ -309,6 +312,7 @@ describe("save / load with the localStorage fallback", () => {
       mode: "years",
       typeface: "system",
       reflection: false,
+      language: "auto",
     });
   });
 
@@ -335,6 +339,7 @@ describe("save / load with the localStorage fallback", () => {
       mode: "years",
       typeface: "system",
       reflection: false,
+      language: "auto",
     });
   });
 });
@@ -527,6 +532,7 @@ describe("save / load against extension storage", () => {
       mode: "years",
       typeface: "system",
       reflection: false,
+      language: "auto",
     });
   });
 
@@ -568,6 +574,7 @@ describe("save / load against extension storage", () => {
       mode: "years",
       typeface: "system",
       reflection: false,
+      language: "auto",
     });
   });
 });

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -39,6 +39,20 @@ function stored() {
   return JSON.parse(localStorage.getItem("mortality"));
 }
 
+function mockLanguageCatalog(messages) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () =>
+        Object.fromEntries(
+          Object.entries(messages).map(([key, message]) => [key, { message }]),
+        ),
+    })),
+  );
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2020-01-01T00:00:00"));
@@ -50,6 +64,7 @@ afterEach(() => {
   vi.resetModules();
   delete globalThis.browser;
   delete globalThis.chrome;
+  vi.unstubAllGlobals();
 });
 
 describe("initial routing", () => {
@@ -100,6 +115,59 @@ describe("initial routing", () => {
       ].map((node) => node.textContent);
       expect(sectionLabels).toContain("de:sectionPresets");
       expect(sectionLabels).toContain("de:sectionLifeExpectancy");
+    });
+
+    it("changes language during setup without losing entered values", async () => {
+      mockLanguageCatalog({
+        pageTitle: "Mortality — Neuer Tab",
+        setupTitle: "Wann wurden Sie geboren?",
+        setupSubtitle: "Ihr Alter zählt in jedem neuen Tab live hoch.",
+        language: "Sprache",
+        languageAutomatic: "Browserstandard",
+      });
+      await boot();
+      document.querySelector("#birth-date").value = "1990-06-15";
+      document.querySelector("#birth-time").value = "09:30";
+
+      const language = document.querySelector("#setup-language");
+      language.value = "de";
+      language.dispatchEvent(new Event("change", { bubbles: true }));
+      await flush();
+
+      expect(stored().language).toBe("de");
+      expect(document.documentElement.lang).toBe("de");
+      expect(document.title).toBe("Mortality — Neuer Tab");
+      expect(document.querySelector(".screen-title").textContent).toBe(
+        "Wann wurden Sie geboren?",
+      );
+      expect(document.querySelector("#birth-date").value).toBe("1990-06-15");
+      expect(document.querySelector("#birth-time").value).toBe("09:30");
+    });
+
+    it("changes language from settings and keeps it on the counter", async () => {
+      mockLanguageCatalog({
+        pageTitle: "Mortality — Neuer Tab",
+        settings: "Einstellungen",
+        language: "Sprache",
+        languageAutomatic: "Browserstandard",
+        sectionDisplay: "Anzeige",
+        modeYears: "Alter",
+      });
+      seed({ birth: "2000-01-01T00:00", mode: "years" });
+      await boot();
+      document.querySelector("#gear").click();
+
+      const language = document.querySelector("#settings-language");
+      language.value = "de";
+      language.dispatchEvent(new Event("change", { bubbles: true }));
+      await flush();
+
+      expect(stored().language).toBe("de");
+      expect(document.querySelector(".screen-title").textContent).toBe(
+        "Einstellungen",
+      );
+      document.querySelector("#done").click();
+      expect(document.querySelector("#unit-label").textContent).toBe("Alter");
     });
   });
 

--- a/test/tab.test.js
+++ b/test/tab.test.js
@@ -130,6 +130,7 @@ describe("mergeImported", () => {
     mode: "years",
     typeface: "system",
     reflection: false,
+    language: "auto",
   };
 
   it("copies known keys from the import", () => {
@@ -140,6 +141,7 @@ describe("mergeImported", () => {
       mode: "days",
       typeface: "mono",
       reflection: true,
+      language: "pt-BR",
     });
     expect(merged.birth).toBe("1990-05-15T09:00");
     expect(merged.birthZone).toBe("Europe/London");
@@ -147,6 +149,7 @@ describe("mergeImported", () => {
     expect(merged.mode).toBe("days");
     expect(merged.typeface).toBe("mono");
     expect(merged.reflection).toBe(true);
+    expect(merged.language).toBe("pt_BR");
   });
 
   it("clamps an imported expectancy into range", () => {
@@ -197,6 +200,12 @@ describe("mergeImported", () => {
     expect(mergeImported(current, { reflection: "" }).reflection).toBe(false);
   });
 
+  it("falls back to the browser language for an unknown imported language", () => {
+    expect(mergeImported(current, { language: "klingon" }).language).toBe(
+      "auto",
+    );
+  });
+
   it("keeps a non-string birth from corrupting state", () => {
     expect(mergeImported(current, { birth: 12345 }).birth).toBeNull();
   });
@@ -218,6 +227,7 @@ describe("mergeImported", () => {
     expect(merged.expectancy).toBe(current.expectancy);
     expect(merged.typeface).toBe(current.typeface);
     expect(merged.reflection).toBe(current.reflection);
+    expect(merged.language).toBe(current.language);
   });
 
   it("tolerates a non-object import", () => {

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderSetup, renderCounter, renderSettings } from "../src/views.js";
 import { THEME_KEYS, PRESETS, cssDefault } from "../src/store.js";
+import { SUPPORTED_LANGUAGES } from "../src/i18n.js";
 
 let app;
 beforeEach(() => {
@@ -19,6 +20,32 @@ describe("renderSetup", () => {
     expect(app.querySelector("#birth-date")).not.toBeNull();
     expect(app.querySelector("#birth-time")).not.toBeNull();
     expect(app.querySelector("#start")).not.toBeNull();
+  });
+
+  it("offers every language on first run and preserves draft fields on change", () => {
+    const setLanguage = vi.fn();
+    renderSetup(
+      app,
+      { start: vi.fn(), setLanguage },
+      "1990-05-15T14:30",
+      "Asia/Tokyo",
+      "female",
+      "us",
+      "fr",
+    );
+    const language = app.querySelector("#setup-language");
+    expect(language.value).toBe("fr");
+    expect(language.options).toHaveLength(SUPPORTED_LANGUAGES.length + 1);
+    expect(language.options[0].textContent).toBe("Browser default");
+
+    language.value = "de";
+    language.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(setLanguage).toHaveBeenCalledWith("de", {
+      birth: "1990-05-15T14:30",
+      birthZone: "Asia/Tokyo",
+      sex: "female",
+      lifeTable: "us",
+    });
   });
 
   it("focuses the date field", () => {
@@ -269,6 +296,7 @@ describe("renderSettings", () => {
     setTypeface: vi.fn(),
     toggleReflection: vi.fn(),
     setZone: vi.fn(),
+    setLanguage: vi.fn(),
     exportData: vi.fn(),
     importData: vi.fn(),
   });
@@ -283,6 +311,7 @@ describe("renderSettings", () => {
     typeface: "system",
     reflection: false,
     birthZone: null,
+    language: "auto",
     ...over,
   });
 
@@ -402,6 +431,17 @@ describe("renderSettings", () => {
         .querySelector('[data-typeface="system"]')
         .getAttribute("aria-pressed"),
     ).toBe("false");
+  });
+
+  it("preselects the language and reports changes", () => {
+    const a = actions();
+    renderSettings(app, a, data({ language: "fr" }));
+    const language = app.querySelector("#settings-language");
+    expect(language.value).toBe("fr");
+    expect(language.options).toHaveLength(SUPPORTED_LANGUAGES.length + 1);
+    language.value = "ja";
+    language.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(a.setLanguage).toHaveBeenCalledWith("ja");
   });
 
   it("reports typeface changes when a segment button is clicked", () => {


### PR DESCRIPTION
## Summary
- add a persisted language selector during setup and under Settings → Display
- load any of the 55 bundled locale catalogs on demand, including localized formatting and RTL direction
- preserve unfinished setup values while changing language

## UI changes
The language control uses the existing native select and field styling. Each language identifies itself by its native name, while Browser default preserves the current automatic behavior.

## Validation
- npm run format:check
- npm test
- bash scripts/pack.sh