### PR TITLE
Add searchable time-zone pickers

### DIFF
--- a/src/_locales/am/messages.json
+++ b/src/_locales/am/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "ወደፊት",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "የሰዓት ሰቅ ፈልግ",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "የሚዛመድ የሰዓት ሰቅ የለም",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "أمامك",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "البحث في المناطق الزمنية",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "لا توجد مناطق زمنية مطابقة",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Напред",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Търсене на часови зони",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Няма съвпадащи часови зони",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "সামনে",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "সময় অঞ্চল খুঁজুন",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "কোনো মিলে যাওয়া সময় অঞ্চল নেই",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Per endavant",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Cerca zones horàries",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "No hi ha cap zona horària coincident",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Před vámi",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Hledat časová pásma",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Žádná odpovídající časová pásma",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Tilbage",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Søg efter tidszoner",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Ingen matchende tidszoner",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Voraus",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Zeitzonen durchsuchen",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Keine passenden Zeitzonen",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Μπροστά",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Αναζήτηση ζωνών ώρας",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Δεν βρέθηκαν ζώνες ώρας",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -367,5 +367,13 @@
   "legendAhead": {
     "message": "Ahead",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Search time zones",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "No matching time zones",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/en_AU/messages.json
+++ b/src/_locales/en_AU/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Ahead",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Search time zones",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "No matching time zones",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Ahead",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Search time zones",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "No matching time zones",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Ahead",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Search time zones",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "No matching time zones",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Por delante",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Buscar zonas horarias",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "No hay zonas horarias coincidentes",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/es_419/messages.json
+++ b/src/_locales/es_419/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Por delante",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Buscar zonas horarias",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "No hay zonas horarias coincidentes",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/et/messages.json
+++ b/src/_locales/et/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Ees",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Otsi ajavööndeid",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Sobivaid ajavööndeid ei leitud",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "پیش رو",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "جست‌وجوی منطقه‌های زمانی",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "منطقه زمانی منطبقی یافت نشد",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Edessä",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Hae aikavyöhykkeitä",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Vastaavia aikavyöhykkeitä ei löytynyt",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/fil/messages.json
+++ b/src/_locales/fil/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Pa",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Maghanap ng mga time zone",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Walang tumutugmang time zone",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Devant",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Rechercher des fuseaux horaires",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Aucun fuseau horaire correspondant",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/gu/messages.json
+++ b/src/_locales/gu/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "આગળ છે",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "સમય ઝોન શોધો",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "કોઈ મેળ ખાતો સમય ઝોન નથી",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "קדימה",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "חיפוש אזורי זמן",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "לא נמצאו אזורי זמן תואמים",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "आगे",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "समय क्षेत्र खोजें",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "कोई मिलता-जुलता समय क्षेत्र नहीं",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/hr/messages.json
+++ b/src/_locales/hr/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Pred vama",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Pretraži vremenske zone",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Nema odgovarajućih vremenskih zona",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Előtted",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Időzónák keresése",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Nincs megfelelő időzóna",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Lagi",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Cari zona waktu",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Tidak ada zona waktu yang cocok",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Davanti",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Cerca fusi orari",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Nessun fuso orario corrispondente",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "あと",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "タイムゾーンを検索",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "一致するタイムゾーンはありません",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/kn/messages.json
+++ b/src/_locales/kn/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "ಮುಂದೆ ಇದೆ",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "ಸಮಯ ವಲಯಗಳನ್ನು ಹುಡುಕಿ",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "ಹೊಂದಿಕೆಯಾಗುವ ಸಮಯ ವಲಯಗಳಿಲ್ಲ",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "앞으로",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "시간대 검색",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "일치하는 시간대가 없습니다",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/lt/messages.json
+++ b/src/_locales/lt/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Priekyje",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Ieškoti laiko juostų",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Atitinkančių laiko juostų nėra",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/lv/messages.json
+++ b/src/_locales/lv/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Priekšā",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Meklēt laika joslas",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Nav atbilstošu laika joslu",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "മുന്നിലുണ്ട്",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "സമയ മേഖലകൾ തിരയുക",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "പൊരുത്തപ്പെടുന്ന സമയ മേഖലകളില്ല",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/mr/messages.json
+++ b/src/_locales/mr/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "पुढे आहे",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "वेळ क्षेत्रे शोधा",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "जुळणारे वेळ क्षेत्र नाही",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ms/messages.json
+++ b/src/_locales/ms/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Lagi",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Cari zon waktu",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Tiada zon waktu yang sepadan",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Nog te gaan",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Tijdzones zoeken",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Geen overeenkomende tijdzones",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Igjen",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Søk etter tidssoner",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Ingen samsvarende tidssoner",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Przed Tobą",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Szukaj stref czasowych",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Brak pasujących stref czasowych",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Pela frente",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Pesquisar fusos horários",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Nenhum fuso horário correspondente",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Pela frente",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Pesquisar fusos horários",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Nenhum fuso horário correspondente",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Înainte",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Caută fusuri orare",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Niciun fus orar corespunzător",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Впереди",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Поиск часовых поясов",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Нет подходящих часовых поясов",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Pred vami",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Hľadať časové pásma",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Žiadne zodpovedajúce časové pásma",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Pred vami",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Iskanje časovnih pasov",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Ni ujemajočih se časovnih pasov",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Пред вама",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Претражи временске зоне",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Нема одговарајућих временских зона",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Kvar",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Sök efter tidszoner",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Inga matchande tidszoner",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/sw/messages.json
+++ b/src/_locales/sw/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Ijayo",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Tafuta maeneo ya saa",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Hakuna maeneo ya saa yanayolingana",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "இன்னும் உள்ளது",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "நேர மண்டலங்களைத் தேடுக",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "பொருந்தும் நேர மண்டலங்கள் இல்லை",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "ముందు ఉంది",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "సమయ మండలాలను వెతకండి",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "సరిపోలే సమయ మండలాలు లేవు",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "เหลืออีก",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "ค้นหาเขตเวลา",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "ไม่พบเขตเวลาที่ตรงกัน",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "İleride",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Saat dilimlerinde ara",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Eşleşen saat dilimi yok",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Попереду",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Пошук часових поясів",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Немає відповідних часових поясів",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "Còn lại",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "Tìm kiếm múi giờ",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "Không có múi giờ phù hợp",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "还有",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "搜索时区",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "没有匹配的时区",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -424,5 +424,13 @@
   "legendAhead": {
     "message": "還有",
     "description": "Legend label for future weeks."
+  },
+  "searchTimeZones": {
+    "message": "搜尋時區",
+    "description": "Placeholder for the searchable time-zone field."
+  },
+  "noTimeZones": {
+    "message": "沒有相符的時區",
+    "description": "Empty result shown when no time zones match the search."
   }
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -14,6 +14,8 @@ export const EN_MESSAGES = {
   birthplaceLabel: "Where were you born?",
   birthplaceHint:
     "Defaults to your current time zone. Set it to where you were born so your age stays exact if you move.",
+  searchTimeZones: "Search time zones",
+  noTimeZones: "No matching time zones",
   actuarialBaseline: "Life expectancy data source",
   baselineSetupHint:
     "World data by default. Your time zone never changes this choice.",

--- a/src/search-select.js
+++ b/src/search-select.js
@@ -1,5 +1,7 @@
 import { el } from "./dom.js";
 
+const normalizedOptionText = new WeakMap();
+
 /** Normalize text for forgiving, case- and diacritic-insensitive matching. */
 export function normalizeSearchText(value) {
   return String(value ?? "")
@@ -11,22 +13,29 @@ export function normalizeSearchText(value) {
     .trim();
 }
 
+function optionSearchText(option) {
+  const source = [
+    option.value,
+    option.label,
+    option.meta,
+    option.displayText,
+    option.searchText,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const cached = normalizedOptionText.get(option);
+  if (cached?.source === source) return cached.value;
+  const value = normalizeSearchText(source);
+  normalizedOptionText.set(option, { source, value });
+  return value;
+}
+
 /** Filter option records while preserving their source order. */
 export function filterSearchOptions(options, query) {
   const terms = normalizeSearchText(query).split(" ").filter(Boolean);
   if (!terms.length) return [...options];
   return options.filter((option) => {
-    const haystack = normalizeSearchText(
-      [
-        option.value,
-        option.label,
-        option.meta,
-        option.displayText,
-        option.searchText,
-      ]
-        .filter(Boolean)
-        .join(" "),
-    );
+    const haystack = optionSearchText(option);
     return terms.every((term) => haystack.includes(term));
   });
 }
@@ -144,6 +153,7 @@ export function createSearchSelect({
           class: "search-select-option",
           role: "option",
           "aria-selected": String(option.value === selectedValue),
+          "aria-label": optionDisplayText(option),
           "data-index": index,
           title: optionDisplayText(option),
         };
@@ -257,10 +267,7 @@ export function createSearchSelect({
         { capture: true, signal },
       );
       window.addEventListener("resize", positionPopup, { signal });
-      window.addEventListener("scroll", positionPopup, {
-        capture: true,
-        signal,
-      });
+      window.addEventListener("scroll", positionPopup, { signal });
     }
     positionPopup();
     scrollActiveIntoView();

--- a/src/search-select.js
+++ b/src/search-select.js
@@ -1,0 +1,391 @@
+import { el } from "./dom.js";
+
+/** Normalize text for forgiving, case- and diacritic-insensitive matching. */
+export function normalizeSearchText(value) {
+  return String(value ?? "")
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .replaceAll("_", " ")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Filter option records while preserving their source order. */
+export function filterSearchOptions(options, query) {
+  const terms = normalizeSearchText(query).split(" ").filter(Boolean);
+  if (!terms.length) return [...options];
+  return options.filter((option) => {
+    const haystack = normalizeSearchText(
+      [
+        option.value,
+        option.label,
+        option.meta,
+        option.displayText,
+        option.searchText,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    );
+    return terms.every((term) => haystack.includes(term));
+  });
+}
+
+function optionDisplayText(option) {
+  if (!option) return "";
+  return (
+    option.displayText ??
+    [option.label, option.meta].filter(Boolean).join(" \u00b7 ")
+  );
+}
+
+/**
+ * Build an editable WAI-ARIA combobox backed by a top-layer/fixed listbox.
+ * The selected value is held separately from the visible query text.
+ */
+export function createSearchSelect({
+  id,
+  options,
+  currentValue,
+  placeholder,
+  noResults,
+  onSelect = () => {},
+  disabled = false,
+  inputDir,
+}) {
+  const records = options.filter(
+    (option) =>
+      option &&
+      typeof option.value === "string" &&
+      typeof option.label === "string",
+  );
+  const selected =
+    records.find((option) => option.value === currentValue) ??
+    records[0] ??
+    null;
+  const recordIndexes = new Map(
+    records.map((option, index) => [option, index]),
+  );
+  let selectedValue = selected?.value ?? "";
+  let filtered = records;
+  let activeIndex = -1;
+  let isOpen = false;
+  let globalListeners = null;
+
+  const listboxId = `${id}-listbox`;
+  const input = el("input", {
+    id,
+    class: "search-select-input",
+    type: "text",
+    role: "combobox",
+    "aria-autocomplete": "list",
+    "aria-controls": listboxId,
+    "aria-expanded": "false",
+    autocomplete: "off",
+    autocapitalize: "none",
+    spellcheck: "false",
+    placeholder,
+    disabled,
+    dir: inputDir,
+  });
+  const root = el("div", { class: "search-select" }, input);
+  const listbox = el("div", {
+    id: listboxId,
+    class: "search-select-listbox",
+    role: "listbox",
+  });
+  const empty = el(
+    "p",
+    {
+      class: "search-select-empty",
+      role: "status",
+      "aria-live": "polite",
+      hidden: true,
+    },
+    noResults,
+  );
+  const popup = el(
+    "div",
+    {
+      class: "search-select-popup",
+      popover: "manual",
+      hidden: true,
+      dir: document.documentElement.dir || "ltr",
+    },
+    [listbox, empty],
+  );
+  document.body.append(popup);
+
+  function selectedRecord() {
+    return records.find((option) => option.value === selectedValue) ?? null;
+  }
+
+  function restoreSelectedLabel() {
+    const record = selectedRecord();
+    input.value = record ? optionDisplayText(record) : "";
+  }
+
+  function optionId(option) {
+    return `${id}-option-${recordIndexes.get(option)}`;
+  }
+
+  function scrollActiveIntoView() {
+    if (activeIndex < 0 || !filtered[activeIndex]) return;
+    document
+      .getElementById(optionId(filtered[activeIndex]))
+      ?.scrollIntoView?.({ block: "nearest" });
+  }
+
+  function renderOptions() {
+    listbox.replaceChildren(
+      ...filtered.map((option, index) => {
+        const attrs = {
+          id: optionId(option),
+          class: "search-select-option",
+          role: "option",
+          "aria-selected": String(option.value === selectedValue),
+          "data-index": index,
+          title: optionDisplayText(option),
+        };
+        if (option.dir) attrs.dir = option.dir;
+        const children = [
+          el("span", { class: "search-select-option-label" }, option.label),
+        ];
+        if (option.meta) {
+          children.push(
+            el("span", { class: "search-select-option-meta" }, option.meta),
+          );
+        }
+        const node = el("div", attrs, children);
+        node.classList.toggle("is-active", index === activeIndex);
+        return node;
+      }),
+    );
+    empty.hidden = filtered.length > 0;
+    if (activeIndex >= 0 && filtered[activeIndex]) {
+      input.setAttribute(
+        "aria-activedescendant",
+        optionId(filtered[activeIndex]),
+      );
+    } else {
+      input.removeAttribute("aria-activedescendant");
+    }
+  }
+
+  function positionPopup() {
+    const rect = input.getBoundingClientRect();
+    const viewportWidth =
+      document.documentElement.clientWidth || window.innerWidth;
+    const viewportHeight =
+      document.documentElement.clientHeight || window.innerHeight;
+    const gap = 4;
+    const edge = 8;
+    const width = Math.max(0, Math.min(rect.width, viewportWidth - edge * 2));
+    const below = viewportHeight - rect.bottom - gap - edge;
+    const above = rect.top - gap - edge;
+    const useBelow = below >= 176 || below >= above;
+    const available = Math.max(96, useBelow ? below : above);
+    const left = Math.min(
+      Math.max(edge, rect.left),
+      Math.max(edge, viewportWidth - width - edge),
+    );
+
+    popup.style.width = `${width}px`;
+    popup.style.maxHeight = `${Math.min(320, available)}px`;
+    popup.style.left = `${left}px`;
+    popup.style.top = useBelow
+      ? `${rect.bottom + gap}px`
+      : `${Math.max(edge, rect.top - gap - Math.min(320, available))}px`;
+  }
+
+  function close({ restore = true } = {}) {
+    if (!isOpen) {
+      if (restore) restoreSelectedLabel();
+      return;
+    }
+    isOpen = false;
+    input.setAttribute("aria-expanded", "false");
+    input.removeAttribute("aria-activedescendant");
+    globalListeners?.abort();
+    globalListeners = null;
+    if (typeof popup.hidePopover === "function") {
+      try {
+        popup.hidePopover();
+      } catch {
+        // The fixed-position fallback below is already sufficient.
+      }
+    }
+    popup.hidden = true;
+    if (restore) restoreSelectedLabel();
+  }
+
+  function open(nextOptions = records, preferredIndex = null) {
+    if (disabled) return;
+    filtered = nextOptions;
+    const selectedIndex = filtered.findIndex(
+      (option) => option.value === selectedValue,
+    );
+    activeIndex =
+      preferredIndex == null
+        ? selectedIndex >= 0
+          ? selectedIndex
+          : filtered.length
+            ? 0
+            : -1
+        : preferredIndex;
+    renderOptions();
+    if (!isOpen) {
+      isOpen = true;
+      input.setAttribute("aria-expanded", "true");
+      popup.hidden = false;
+      if (typeof popup.showPopover === "function") {
+        try {
+          popup.showPopover();
+        } catch {
+          // Older engines use the same fixed-position element without top layer.
+        }
+      }
+      globalListeners = new AbortController();
+      const { signal } = globalListeners;
+      document.addEventListener(
+        "pointerdown",
+        (event) => {
+          if (!root.contains(event.target) && !popup.contains(event.target)) {
+            close();
+          }
+        },
+        { capture: true, signal },
+      );
+      window.addEventListener("resize", positionPopup, { signal });
+      window.addEventListener("scroll", positionPopup, {
+        capture: true,
+        signal,
+      });
+    }
+    positionPopup();
+    scrollActiveIntoView();
+  }
+
+  function moveActive(index) {
+    if (!filtered.length) return;
+    const nextIndex = Math.max(0, Math.min(index, filtered.length - 1));
+    if (nextIndex === activeIndex) return;
+    if (activeIndex >= 0 && filtered[activeIndex]) {
+      document
+        .getElementById(optionId(filtered[activeIndex]))
+        ?.classList.remove("is-active");
+    }
+    activeIndex = nextIndex;
+    document
+      .getElementById(optionId(filtered[activeIndex]))
+      ?.classList.add("is-active");
+    input.setAttribute(
+      "aria-activedescendant",
+      optionId(filtered[activeIndex]),
+    );
+    scrollActiveIntoView();
+  }
+
+  function choose(option) {
+    const changed = option.value !== selectedValue;
+    selectedValue = option.value;
+    close();
+    input.focus();
+    if (changed) onSelect(option.value);
+  }
+
+  input.addEventListener("input", () => {
+    const matches = filterSearchOptions(records, input.value);
+    open(matches, matches.length ? 0 : -1);
+  });
+  input.addEventListener("pointerdown", () => {
+    const selectingLabel = input.value === optionDisplayText(selectedRecord());
+    if (!isOpen) open();
+    if (selectingLabel) requestAnimationFrame(() => input.select());
+  });
+  input.addEventListener("focus", () => {
+    if (input.value === optionDisplayText(selectedRecord())) input.select();
+  });
+  input.addEventListener("keydown", (event) => {
+    if (event.isComposing || event.keyCode === 229) return;
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        if (!isOpen) open();
+        else moveActive(activeIndex + 1);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        if (!isOpen) open(records, records.length - 1);
+        else moveActive(activeIndex - 1);
+        break;
+      case "Home":
+        if (isOpen) {
+          event.preventDefault();
+          moveActive(0);
+        }
+        break;
+      case "End":
+        if (isOpen) {
+          event.preventDefault();
+          moveActive(filtered.length - 1);
+        }
+        break;
+      case "Enter":
+        if (isOpen) {
+          event.preventDefault();
+          const option = filtered[activeIndex];
+          if (option) choose(option);
+          else close();
+        }
+        break;
+      case "Escape":
+        if (isOpen) {
+          event.preventDefault();
+          close();
+        }
+        break;
+      case "Tab":
+        close();
+        break;
+    }
+  });
+  input.addEventListener("focusout", () => {
+    queueMicrotask(() => {
+      if (
+        !root.contains(document.activeElement) &&
+        !popup.contains(document.activeElement)
+      ) {
+        close();
+      }
+    });
+  });
+  listbox.addEventListener("pointermove", (event) => {
+    const option = event.target.closest?.('[role="option"]');
+    if (option) moveActive(Number(option.dataset.index));
+  });
+  listbox.addEventListener("pointerdown", (event) => {
+    if (event.button != null && event.button !== 0) return;
+    event.preventDefault();
+  });
+  listbox.addEventListener("click", (event) => {
+    const option = event.target.closest?.('[role="option"]');
+    if (option) choose(filtered[Number(option.dataset.index)]);
+  });
+
+  restoreSelectedLabel();
+
+  return {
+    element: root,
+    input,
+    get value() {
+      return selectedValue;
+    },
+    restore: restoreSelectedLabel,
+    close,
+    destroy() {
+      close();
+      popup.remove();
+    },
+  };
+}

--- a/src/search-select.js
+++ b/src/search-select.js
@@ -308,15 +308,6 @@ export function createSearchSelect({
   });
   input.addEventListener("keydown", (event) => {
     if (event.isComposing || event.keyCode === 229) return;
-    if (
-      !event.altKey &&
-      (event.metaKey || event.ctrlKey) &&
-      event.key.toLowerCase() === "a"
-    ) {
-      event.preventDefault();
-      input.select();
-      return;
-    }
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();

--- a/src/search-select.js
+++ b/src/search-select.js
@@ -308,6 +308,15 @@ export function createSearchSelect({
   });
   input.addEventListener("keydown", (event) => {
     if (event.isComposing || event.keyCode === 229) return;
+    if (
+      !event.altKey &&
+      (event.metaKey || event.ctrlKey) &&
+      event.key.toLowerCase() === "a"
+    ) {
+      event.preventDefault();
+      input.select();
+      return;
+    }
     switch (event.key) {
       case "ArrowDown":
         event.preventDefault();

--- a/src/tab.css
+++ b/src/tab.css
@@ -9,6 +9,7 @@
   --input-text: #494949;
   --on-accent: #ffffff;
   --focus: #005f80;
+  --layer-dropdown: 10;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -390,6 +391,114 @@ footer {
   cursor: pointer;
 }
 
+.search-select {
+  width: 100%;
+  min-width: 0;
+}
+
+.search-select-input {
+  width: 100%;
+  min-width: 0;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.75rem;
+  overflow: hidden;
+  color: var(--input-text);
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  background-color: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+}
+
+.search-select-input[dir="ltr"] {
+  text-align: left;
+  unicode-bidi: isolate;
+}
+
+.search-select-input::placeholder {
+  color: var(--input-text);
+  opacity: 1;
+}
+
+.search-select-input:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.search-select-popup {
+  position: fixed;
+  inset: auto;
+  z-index: var(--layer-dropdown);
+  min-width: 0;
+  max-width: calc(100vw - 1rem);
+  margin: 0;
+  padding: 0.25rem;
+  overflow: hidden;
+  color: var(--input-text);
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: 0.25rem;
+}
+
+.search-select-listbox {
+  max-height: inherit;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.search-select-option {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.25rem;
+  cursor: default;
+}
+
+.search-select-option:hover,
+.search-select-option.is-active {
+  background: color-mix(in srgb, var(--label) 16%, transparent);
+}
+
+.search-select-option:active {
+  background: color-mix(in srgb, var(--label) 24%, transparent);
+}
+
+.search-select-option[aria-selected="true"] {
+  color: var(--count);
+  font-weight: 600;
+}
+
+.search-select-option-label {
+  min-width: 0;
+  overflow: hidden;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-select-option-meta {
+  flex: none;
+  margin-inline-start: auto;
+  color: var(--label);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.search-select-empty {
+  margin: 0;
+  padding: 0.75rem 0.65rem;
+  color: var(--label);
+  font-size: 0.9rem;
+  line-height: 1.4;
+  text-align: start;
+}
+
 .hint {
   margin: 0;
   color: var(--label);
@@ -689,12 +798,6 @@ footer {
   inset-inline-start: calc(100% - 1.23rem);
 }
 
-.bidi-id {
-  direction: ltr;
-  text-align: left;
-  unicode-bidi: isolate;
-}
-
 :dir(rtl) #weeks-back {
   transform: scaleX(-1);
 }
@@ -732,6 +835,22 @@ footer {
 @media (max-width: 360px) {
   #app {
     padding-inline: 1rem;
+  }
+
+  .setup-row {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+    width: 100%;
+    max-width: 22rem;
+  }
+
+  .setup-row :is(input[type="date"], input[type="time"]) {
+    width: 100%;
+    min-width: 0;
+    min-height: 2.75rem;
+    margin-inline-end: 0;
+    font-size: 1rem;
   }
 
   .row {

--- a/src/time.js
+++ b/src/time.js
@@ -290,3 +290,47 @@ export function listTimeZones(...ensure) {
   }
   return [...set].sort();
 }
+
+/** Turn an IANA id into a readable but deliberately non-localized label. */
+export function humanizeTimeZone(zone) {
+  return String(zone)
+    .split("/")
+    .map((part) => part.replaceAll("_", " "))
+    .join(" / ");
+}
+
+/** Format a UTC offset, preserving half- and quarter-hour offsets. */
+export function formatUtcOffset(offsetMs) {
+  if (!Number.isFinite(offsetMs)) {
+    throw new TypeError("Time-zone offset must be finite");
+  }
+  const totalMinutes = Math.round(offsetMs / 60000);
+  if (totalMinutes === 0) return "UTC";
+  const sign = totalMinutes < 0 ? "-" : "+";
+  const absolute = Math.abs(totalMinutes);
+  const hours = String(Math.floor(absolute / 60)).padStart(2, "0");
+  const minutes = String(absolute % 60).padStart(2, "0");
+  return `UTC${sign}${hours}:${minutes}`;
+}
+
+/**
+ * Search-select records for every supported time zone at one frozen instant.
+ * Canonical values are never humanized or otherwise altered.
+ */
+export function buildTimeZoneOptions(selected, detected, nowMs = Date.now()) {
+  return listTimeZones(selected, detected).map((zone) => {
+    const label = humanizeTimeZone(zone);
+    const offset = isValidZone(zone)
+      ? formatUtcOffset(zoneOffsetMsAt(nowMs, zone))
+      : "";
+    const meta = label === "UTC" && offset === "UTC" ? "" : offset;
+    return {
+      value: zone,
+      label,
+      meta,
+      displayText: [label, meta].filter(Boolean).join(" \u00b7 "),
+      searchText: `${zone} ${label} ${meta}`,
+      dir: "ltr",
+    };
+  });
+}

--- a/src/views.js
+++ b/src/views.js
@@ -207,7 +207,6 @@ export function renderSetup(
     noResults: msg("noTimeZones"),
     inputDir: "ltr",
   });
-  const zoneEl = zoneControl.input;
   const sexEl = sexSelect("birth-sex", savedSex);
   const lifeTableEl = lifeTableSelect("birth-life-table", savedLifeTable);
   const languageEl = languageSelect("setup-language", savedLanguage);

--- a/src/views.js
+++ b/src/views.js
@@ -8,7 +8,7 @@ import {
   contrast,
   bestOnColor,
 } from "./store.js";
-import { listTimeZones, detectZone } from "./time.js";
+import { buildTimeZoneOptions, detectZone } from "./time.js";
 import {
   DEFAULT_LIFE_TABLE,
   LIFE_TABLE_OPTIONS,
@@ -23,6 +23,7 @@ import {
   msg,
   normalizeLanguage,
 } from "./i18n.js";
+import { createSearchSelect } from "./search-select.js";
 
 const COLOR_LABELS = {
   bg: "colorBackground",
@@ -53,6 +54,12 @@ const PRESET_LABELS = {
 const CONTRAST_MIN = { count: 4.5, label: 4.5, accent: 3 };
 
 const SVG_NS = "http://www.w3.org/2000/svg";
+const viewCleanups = new WeakMap();
+
+function cleanupView(app) {
+  viewCleanups.get(app)?.();
+  viewCleanups.delete(app);
+}
 
 /** Build an SVG node. el() uses createElement (HTML only), so icons need this. */
 function svgEl(tag, attrs = {}, children = []) {
@@ -176,6 +183,7 @@ export function renderSetup(
   savedLifeTable,
   savedLanguage,
 ) {
+  cleanupView(app);
   const dateEl = el("input", {
     type: "date",
     id: "birth-date",
@@ -191,14 +199,15 @@ export function renderSetup(
   });
   const detected = detectZone();
   const selectedZone = savedZone || detected;
-  const zoneEl = el(
-    "select",
-    { id: "birth-zone", class: "bidi-id" },
-    listTimeZones(selectedZone, detected).map((zone) =>
-      el("option", { value: zone }, zone),
-    ),
-  );
-  zoneEl.value = selectedZone;
+  const zoneControl = createSearchSelect({
+    id: "birth-zone",
+    options: buildTimeZoneOptions(selectedZone, detected),
+    currentValue: selectedZone,
+    placeholder: msg("searchTimeZones"),
+    noResults: msg("noTimeZones"),
+    inputDir: "ltr",
+  });
+  const zoneEl = zoneControl.input;
   const sexEl = sexSelect("birth-sex", savedSex);
   const lifeTableEl = lifeTableSelect("birth-life-table", savedLifeTable);
   const languageEl = languageSelect("setup-language", savedLanguage);
@@ -229,7 +238,7 @@ export function renderSetup(
         { class: "setup-label", for: "birth-zone" },
         msg("birthplaceLabel"),
       ),
-      zoneEl,
+      zoneControl.element,
       el("p", { class: "hint" }, msg("birthplaceHint")),
     ]),
     el("div", { class: "setup-field" }, [
@@ -253,6 +262,7 @@ export function renderSetup(
     el("footer", {}, [startBtn]),
   ]);
   app.replaceChildren(form);
+  viewCleanups.set(app, () => zoneControl.destroy());
 
   if (current) {
     const [date, time] = splitBirth(current);
@@ -271,8 +281,9 @@ export function renderSetup(
       dateEl.focus();
       return;
     }
+    zoneControl.restore();
     errorEl.hidden = true;
-    start(birth, zoneEl.value, sexEl.value || null, lifeTableEl.value);
+    start(birth, zoneControl.value, sexEl.value || null, lifeTableEl.value);
   }
   form.addEventListener("submit", (event) => {
     event.preventDefault();
@@ -287,14 +298,15 @@ export function renderSetup(
     const birth = dateEl.value
       ? `${dateEl.value}T${timeEl.value || "00:00"}`
       : null;
+    zoneControl.restore();
     setLanguage(languageEl.value, {
       birth,
-      birthZone: zoneEl.value,
+      birthZone: zoneControl.value,
       sex: sexEl.value || null,
       lifeTable: lifeTableEl.value,
     });
   });
-  [dateEl, timeEl, zoneEl, lifeTableEl, sexEl].forEach((input) =>
+  [dateEl, timeEl, lifeTableEl, sexEl].forEach((input) =>
     input.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
         event.preventDefault();
@@ -311,6 +323,7 @@ export function renderCounter(
   { openSettings, onCycle, openWeeks },
   { born, reflection },
 ) {
+  cleanupView(app);
   const gear = el(
     "button",
     {
@@ -408,6 +421,7 @@ export function renderSettings(
     language,
   },
 ) {
+  cleanupView(app);
   const colorInputs = {};
   const notes = {};
   const languageEl = languageSelect("settings-language", language);
@@ -554,17 +568,15 @@ export function renderSettings(
   // Time zone: re-anchor the birth instant to a different zone after setup.
   const detected = detectZone();
   const selectedZone = birthZone || detected;
-  const zoneSelect = el(
-    "select",
-    { id: "settings-zone", class: "bidi-id" },
-    listTimeZones(selectedZone, detected).map((zone) =>
-      el("option", { value: zone }, zone),
-    ),
-  );
-  zoneSelect.value = selectedZone;
-  zoneSelect.addEventListener("change", (event) =>
-    actions.setZone(event.target.value),
-  );
+  const zoneControl = createSearchSelect({
+    id: "settings-zone",
+    options: buildTimeZoneOptions(selectedZone, detected),
+    currentValue: selectedZone,
+    placeholder: msg("searchTimeZones"),
+    noResults: msg("noTimeZones"),
+    inputDir: "ltr",
+    onSelect: actions.setZone,
+  });
 
   // Data: export the whole state as JSON, or import a previously saved file.
   const exportBtn = el(
@@ -629,7 +641,7 @@ export function renderSettings(
         { class: "setup-label", for: "settings-zone" },
         msg("bornIn"),
       ),
-      zoneSelect,
+      zoneControl.element,
       el("p", { class: "hint" }, msg("zoneHint")),
     ]),
     el("p", { class: "settings-label" }, msg("sectionData")),
@@ -638,6 +650,7 @@ export function renderSettings(
     el("div", { class: "actions" }, [doneBtn]),
   ]);
   app.replaceChildren(settings);
+  viewCleanups.set(app, () => zoneControl.destroy());
 
   function activePreset() {
     return (
@@ -716,6 +729,7 @@ export function renderWeeks(
   { back, openSettings },
   { born, lived, total, expectancy },
 ) {
+  cleanupView(app);
   const backBtn = el(
     "button",
     {

--- a/test/search-select.test.js
+++ b/test/search-select.test.js
@@ -46,12 +46,11 @@ function build(overrides = {}) {
   return control;
 }
 
-function keydown(element, key, modifiers = {}) {
+function keydown(element, key) {
   const event = new KeyboardEvent("keydown", {
     key,
     bubbles: true,
     cancelable: true,
-    ...modifiers,
   });
   element.dispatchEvent(event);
   return event;
@@ -152,19 +151,6 @@ describe("search select", () => {
     expect(control.input.selectionStart).toBe(0);
     expect(control.input.selectionEnd).toBe(control.input.value.length);
   });
-
-  it.each([{ metaKey: true }, { ctrlKey: true }])(
-    "selects the entire query for the platform select-all shortcut",
-    (modifier) => {
-      const control = build();
-      query(control, "new york");
-      control.input.setSelectionRange(3, 3);
-      const event = keydown(control.input, "a", modifier);
-      expect(event.defaultPrevented).toBe(true);
-      expect(control.input.selectionStart).toBe(0);
-      expect(control.input.selectionEnd).toBe(control.input.value.length);
-    },
-  );
 
   it("filters as the user types and keeps the selected value stable", () => {
     const control = build();

--- a/test/search-select.test.js
+++ b/test/search-select.test.js
@@ -74,6 +74,14 @@ describe("search normalization", () => {
       OPTIONS[0],
     ]);
   });
+
+  it("refreshes a cached option when its searchable text changes", () => {
+    const option = { value: "one", label: "One", searchText: "before" };
+    expect(filterSearchOptions([option], "before")).toEqual([option]);
+    option.searchText = "after";
+    expect(filterSearchOptions([option], "before")).toEqual([]);
+    expect(filterSearchOptions([option], "after")).toEqual([option]);
+  });
 });
 
 describe("search select", () => {
@@ -93,6 +101,9 @@ describe("search select", () => {
       "listbox",
     );
     expect(input.getAttribute("aria-activedescendant")).toBe("zone-option-1");
+    expect(
+      document.querySelector("#zone-option-1").getAttribute("aria-label"),
+    ).toBe("Asia / Tokyo · UTC+09:00");
   });
 
   it("supports arrows, Home, End, and Enter without submitting", () => {
@@ -204,6 +215,18 @@ describe("search select", () => {
     );
     expect(control.input.getAttribute("aria-expanded")).toBe("false");
     expect(control.input.value).toBe("Asia / Tokyo · UTC+09:00");
+  });
+
+  it("repositions for page scroll without reacting to listbox scroll", () => {
+    const control = build();
+    keydown(control.input, "ArrowDown");
+    const rect = vi.spyOn(control.input, "getBoundingClientRect");
+    document
+      .querySelector(".search-select-listbox")
+      .dispatchEvent(new Event("scroll"));
+    expect(rect).not.toHaveBeenCalled();
+    window.dispatchEvent(new Event("scroll"));
+    expect(rect).toHaveBeenCalledOnce();
   });
 
   it("selects a pointer or touch result exactly once", () => {

--- a/test/search-select.test.js
+++ b/test/search-select.test.js
@@ -46,11 +46,12 @@ function build(overrides = {}) {
   return control;
 }
 
-function keydown(element, key) {
+function keydown(element, key, modifiers = {}) {
   const event = new KeyboardEvent("keydown", {
     key,
     bubbles: true,
     cancelable: true,
+    ...modifiers,
   });
   element.dispatchEvent(event);
   return event;
@@ -151,6 +152,19 @@ describe("search select", () => {
     expect(control.input.selectionStart).toBe(0);
     expect(control.input.selectionEnd).toBe(control.input.value.length);
   });
+
+  it.each([{ metaKey: true }, { ctrlKey: true }])(
+    "selects the entire query for the platform select-all shortcut",
+    (modifier) => {
+      const control = build();
+      query(control, "new york");
+      control.input.setSelectionRange(3, 3);
+      const event = keydown(control.input, "a", modifier);
+      expect(event.defaultPrevented).toBe(true);
+      expect(control.input.selectionStart).toBe(0);
+      expect(control.input.selectionEnd).toBe(control.input.value.length);
+    },
+  );
 
   it("filters as the user types and keeps the selected value stable", () => {
     const control = build();

--- a/test/search-select.test.js
+++ b/test/search-select.test.js
@@ -1,0 +1,246 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSearchSelect,
+  filterSearchOptions,
+  normalizeSearchText,
+} from "../src/search-select.js";
+
+const OPTIONS = [
+  {
+    value: "America/New_York",
+    label: "America / New York",
+    meta: "UTC-05:00",
+    searchText: "America/New_York",
+    dir: "ltr",
+  },
+  {
+    value: "Asia/Tokyo",
+    label: "Asia / Tokyo",
+    meta: "UTC+09:00",
+    dir: "ltr",
+  },
+  {
+    value: "Europe/Paris",
+    label: "Europe / Páris",
+    meta: "UTC+01:00",
+    dir: "ltr",
+  },
+];
+const controls = [];
+
+afterEach(() => {
+  controls.splice(0).forEach((control) => control.destroy());
+});
+
+function build(overrides = {}) {
+  const control = createSearchSelect({
+    id: "zone",
+    options: OPTIONS,
+    currentValue: "Asia/Tokyo",
+    placeholder: "Search",
+    noResults: "Nothing found",
+    ...overrides,
+  });
+  document.body.append(control.element);
+  controls.push(control);
+  return control;
+}
+
+function keydown(element, key) {
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  element.dispatchEvent(event);
+  return event;
+}
+
+function query(control, value) {
+  control.input.value = value;
+  control.input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("search normalization", () => {
+  it("folds case, diacritics, underscores, and whitespace", () => {
+    expect(normalizeSearchText("  PÁRIS_New   York ")).toBe("paris new york");
+    expect(normalizeSearchText("Indiana")).toBe("indiana");
+  });
+
+  it("matches every query term across option metadata", () => {
+    expect(filterSearchOptions(OPTIONS, "ASIA utc+09")).toEqual([OPTIONS[1]]);
+    expect(filterSearchOptions(OPTIONS, "paris")).toEqual([OPTIONS[2]]);
+    expect(filterSearchOptions(OPTIONS, "America/New_York")).toEqual([
+      OPTIONS[0],
+    ]);
+  });
+});
+
+describe("search select", () => {
+  it("wires the editable combobox and listbox ARIA pattern", () => {
+    const control = build();
+    const input = control.input;
+    expect(input.getAttribute("role")).toBe("combobox");
+    expect(input.getAttribute("aria-autocomplete")).toBe("list");
+    expect(input.getAttribute("aria-expanded")).toBe("false");
+    expect(input.getAttribute("aria-controls")).toBe("zone-listbox");
+    expect(control.value).toBe("Asia/Tokyo");
+    expect(input.value).toBe("Asia / Tokyo · UTC+09:00");
+
+    keydown(input, "ArrowDown");
+    expect(input.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector("#zone-listbox").getAttribute("role")).toBe(
+      "listbox",
+    );
+    expect(input.getAttribute("aria-activedescendant")).toBe("zone-option-1");
+  });
+
+  it("supports arrows, Home, End, and Enter without submitting", () => {
+    const onSelect = vi.fn();
+    const control = build({ onSelect });
+    const input = control.input;
+
+    keydown(input, "ArrowDown");
+    keydown(input, "End");
+    expect(input.getAttribute("aria-activedescendant")).toBe("zone-option-2");
+    const enter = keydown(input, "Enter");
+    expect(enter.defaultPrevented).toBe(true);
+    expect(control.value).toBe("Europe/Paris");
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith("Europe/Paris");
+
+    keydown(input, "ArrowDown");
+    keydown(input, "Home");
+    keydown(input, "Enter");
+    expect(control.value).toBe("America/New_York");
+  });
+
+  it("opens at the final option with Arrow Up", () => {
+    const control = build();
+    keydown(control.input, "ArrowUp");
+    expect(control.input.getAttribute("aria-expanded")).toBe("true");
+    expect(control.input.getAttribute("aria-activedescendant")).toBe(
+      "zone-option-2",
+    );
+  });
+
+  it("leaves closed Enter to the containing form", () => {
+    const control = build();
+    expect(keydown(control.input, "Enter").defaultPrevented).toBe(false);
+  });
+
+  it("does not treat IME confirmation as option selection", () => {
+    const onSelect = vi.fn();
+    const control = build({ onSelect });
+    query(control, "paris");
+    const event = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+      isComposing: true,
+    });
+    control.input.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+    expect(control.value).toBe("Asia/Tokyo");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("selects the displayed label on focus so typing replaces it", () => {
+    const control = build();
+    control.input.focus();
+    expect(control.input.selectionStart).toBe(0);
+    expect(control.input.selectionEnd).toBe(control.input.value.length);
+  });
+
+  it("filters as the user types and keeps the selected value stable", () => {
+    const control = build();
+    query(control, "new york");
+    expect(
+      [...document.querySelectorAll('[role="option"]')].map(
+        (option) => option.textContent,
+      ),
+    ).toEqual(["America / New YorkUTC-05:00"]);
+    expect(control.value).toBe("Asia/Tokyo");
+  });
+
+  it("shows an accessible empty state for no matches", () => {
+    const control = build();
+    query(control, "not a real zone");
+    expect(document.querySelectorAll('[role="option"]')).toHaveLength(0);
+    const empty = document.querySelector(".search-select-empty");
+    expect(empty.hidden).toBe(false);
+    expect(empty.getAttribute("role")).toBe("status");
+    expect(empty.textContent).toBe("Nothing found");
+  });
+
+  it("shows the empty state when no options are available", () => {
+    const control = build({ options: [], currentValue: "" });
+    keydown(control.input, "ArrowDown");
+    expect(control.input.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector(".search-select-empty").hidden).toBe(false);
+  });
+
+  it("restores invalid free text on Escape, Tab, and blur", async () => {
+    const control = build();
+    for (const key of ["Escape", "Tab"]) {
+      query(control, "invalid");
+      keydown(control.input, key);
+      expect(control.input.value).toBe("Asia / Tokyo · UTC+09:00");
+      expect(control.value).toBe("Asia/Tokyo");
+    }
+
+    query(control, "still invalid");
+    control.input.focus();
+    control.input.blur();
+    await Promise.resolve();
+    expect(control.input.value).toBe("Asia / Tokyo · UTC+09:00");
+  });
+
+  it("light-dismisses and restores the selected label", () => {
+    const control = build();
+    query(control, "invalid");
+    document.body.dispatchEvent(
+      new Event("pointerdown", { bubbles: true, cancelable: true }),
+    );
+    expect(control.input.getAttribute("aria-expanded")).toBe("false");
+    expect(control.input.value).toBe("Asia / Tokyo · UTC+09:00");
+  });
+
+  it("selects a pointer or touch result exactly once", () => {
+    const onSelect = vi.fn();
+    const control = build({ onSelect });
+    query(control, "new york");
+    document.querySelector('[role="option"]').click();
+    expect(control.value).toBe("America/New_York");
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+
+  it("moves the pointer-active state without rebuilding option nodes", () => {
+    const control = build();
+    keydown(control.input, "ArrowDown");
+    const first = document.querySelector("#zone-option-0");
+    const third = document.querySelector("#zone-option-2");
+    third.dispatchEvent(new Event("pointermove", { bubbles: true }));
+    expect(document.querySelector("#zone-option-0")).toBe(first);
+    expect(third.classList.contains("is-active")).toBe(true);
+    expect(control.input.getAttribute("aria-activedescendant")).toBe(
+      "zone-option-2",
+    );
+  });
+
+  it("does not open when disabled", () => {
+    const control = build({ disabled: true });
+    expect(control.input.disabled).toBe(true);
+    keydown(control.input, "ArrowDown");
+    expect(control.input.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("removes its portalled popup and open listeners on destroy", () => {
+    const control = build();
+    const abort = vi.spyOn(AbortController.prototype, "abort");
+    keydown(control.input, "ArrowDown");
+    control.destroy();
+    expect(abort).toHaveBeenCalledOnce();
+    expect(document.querySelector(".search-select-popup")).toBeNull();
+  });
+});

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -699,8 +699,9 @@ describe("settings: display, reflection, and zone", () => {
     await boot();
     document.querySelector("#gear").click();
     const zone = document.querySelector("#settings-zone");
-    zone.value = "Asia/Tokyo";
-    zone.dispatchEvent(new Event("change", { bubbles: true }));
+    zone.value = "tokyo";
+    zone.dispatchEvent(new Event("input", { bubbles: true }));
+    document.querySelector('[role="option"]').click();
     expect(stored().birthZone).toBe("Asia/Tokyo");
   });
 });

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -11,6 +11,9 @@ import {
   isValidZone,
   detectZone,
   listTimeZones,
+  humanizeTimeZone,
+  formatUtcOffset,
+  buildTimeZoneOptions,
 } from "../src/time.js";
 
 const HOUR_MS = 3600000;
@@ -321,5 +324,86 @@ describe("listTimeZones", () => {
     const zones = listTimeZones("Custom/Place", "Asia/Tokyo");
     expect(zones).toContain("Custom/Place");
     expect(zones.filter((z) => z === "Asia/Tokyo")).toHaveLength(1);
+  });
+});
+
+describe("time-zone picker records", () => {
+  it("humanizes IANA paths without changing their canonical value", () => {
+    expect(humanizeTimeZone("America/Argentina/Buenos_Aires")).toBe(
+      "America / Argentina / Buenos Aires",
+    );
+  });
+
+  it("formats zero, positive, negative, half-, and quarter-hour offsets", () => {
+    expect(formatUtcOffset(0)).toBe("UTC");
+    expect(formatUtcOffset(9 * HOUR_MS)).toBe("UTC+09:00");
+    expect(formatUtcOffset(-5 * HOUR_MS)).toBe("UTC-05:00");
+    expect(formatUtcOffset(5.5 * HOUR_MS)).toBe("UTC+05:30");
+    expect(formatUtcOffset(5.75 * HOUR_MS)).toBe("UTC+05:45");
+  });
+
+  it("builds searchable labels using offsets at the supplied instant", () => {
+    const winter = Date.UTC(2024, 0, 15, 12);
+    const records = buildTimeZoneOptions("UTC", "America/New_York", winter);
+    expect(records.find(({ value }) => value === "UTC")).toMatchObject({
+      value: "UTC",
+      label: "UTC",
+      meta: "",
+      displayText: "UTC",
+    });
+    expect(
+      records.find(({ value }) => value === "America/New_York"),
+    ).toMatchObject({
+      label: "America / New York",
+      meta: "UTC-05:00",
+    });
+    expect(records.find(({ value }) => value === "Asia/Tokyo").meta).toBe(
+      "UTC+09:00",
+    );
+    const quarterHour = buildTimeZoneOptions("Asia/Kathmandu", "UTC", winter);
+    expect(
+      quarterHour.find(({ value }) => value === "Asia/Kathmandu").meta,
+    ).toBe("UTC+05:45");
+  });
+
+  it("uses the current DST offset at the frozen render instant", () => {
+    const winter = buildTimeZoneOptions(
+      "America/New_York",
+      "UTC",
+      Date.UTC(2024, 0, 15, 12),
+    );
+    const summer = buildTimeZoneOptions(
+      "America/New_York",
+      "UTC",
+      Date.UTC(2024, 6, 15, 12),
+    );
+    expect(winter.find(({ value }) => value === "America/New_York").meta).toBe(
+      "UTC-05:00",
+    );
+    expect(summer.find(({ value }) => value === "America/New_York").meta).toBe(
+      "UTC-04:00",
+    );
+  });
+
+  it("retains the curated zones when supportedValuesOf is unavailable", () => {
+    const original = Intl.supportedValuesOf;
+    Object.defineProperty(Intl, "supportedValuesOf", {
+      value: undefined,
+      configurable: true,
+    });
+    try {
+      const records = buildTimeZoneOptions(
+        "Asia/Tokyo",
+        "UTC",
+        Date.UTC(2024, 0, 1),
+      );
+      expect(records.map(({ value }) => value)).toContain("Asia/Tokyo");
+      expect(records.map(({ value }) => value)).toContain("America/New_York");
+    } finally {
+      Object.defineProperty(Intl, "supportedValuesOf", {
+        value: original,
+        configurable: true,
+      });
+    }
   });
 });

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { renderSetup, renderCounter, renderSettings } from "../src/views.js";
 import { THEME_KEYS, PRESETS, cssDefault } from "../src/store.js";
+import { detectZone } from "../src/time.js";
 import { SUPPORTED_LANGUAGES } from "../src/i18n.js";
 
 let app;
-const detectedZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const detectedZone = detectZone();
 beforeEach(() => {
   app = document.createElement("div");
   app.id = "app";

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -4,6 +4,7 @@ import { THEME_KEYS, PRESETS, cssDefault } from "../src/store.js";
 import { SUPPORTED_LANGUAGES } from "../src/i18n.js";
 
 let app;
+const detectedZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 beforeEach(() => {
   app = document.createElement("div");
   app.id = "app";
@@ -11,7 +12,13 @@ beforeEach(() => {
 });
 
 function keydown(el, key) {
-  el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+  });
+  el.dispatchEvent(event);
+  return event;
 }
 
 describe("renderSetup", () => {
@@ -70,22 +77,30 @@ describe("renderSetup", () => {
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "2000-03-04";
     app.querySelector("#birth-time").value = "09:15";
-    const zone = app.querySelector("#birth-zone").value;
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2000-03-04T09:15", zone, null, "world");
+    expect(start).toHaveBeenCalledWith(
+      "2000-03-04T09:15",
+      detectedZone,
+      null,
+      "world",
+    );
   });
 
   it("defaults an empty time to midnight", () => {
     const start = vi.fn();
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "2010-10-10";
-    const zone = app.querySelector("#birth-zone").value;
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("2010-10-10T00:00", zone, null, "world");
+    expect(start).toHaveBeenCalledWith(
+      "2010-10-10T00:00",
+      detectedZone,
+      null,
+      "world",
+    );
   });
 
   it("blocks submission and reports validity when the date is empty", () => {
@@ -104,17 +119,27 @@ describe("renderSetup", () => {
     const start = vi.fn();
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "1975-12-25";
-    const zone = app.querySelector("#birth-zone").value;
     keydown(app.querySelector("#birth-date"), "Enter");
-    expect(start).toHaveBeenCalledWith("1975-12-25T00:00", zone, null, "world");
+    expect(start).toHaveBeenCalledWith(
+      "1975-12-25T00:00",
+      detectedZone,
+      null,
+      "world",
+    );
   });
 
-  it("renders a birthplace time-zone select defaulting to the device zone", () => {
+  it("renders a birthplace time-zone combobox defaulting to the device zone", () => {
     renderSetup(app, { start: vi.fn() }, null);
     const zone = app.querySelector("#birth-zone");
     expect(zone).not.toBeNull();
-    expect(zone.tagName).toBe("SELECT");
-    expect(zone.value).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    expect(zone.tagName).toBe("INPUT");
+    expect(zone.getAttribute("role")).toBe("combobox");
+    expect(zone.value).toContain(
+      detectedZone
+        .split("/")
+        .map((part) => part.replaceAll("_", " "))
+        .join(" / "),
+    );
     // The visible label is associated with the control for accessibility.
     const label = app.querySelector('label[for="birth-zone"]');
     expect(label).not.toBeNull();
@@ -123,7 +148,49 @@ describe("renderSetup", () => {
 
   it("pre-selects the saved birth zone when editing", () => {
     renderSetup(app, { start: vi.fn() }, "1990-05-15T00:00", "Asia/Tokyo");
-    expect(app.querySelector("#birth-zone").value).toBe("Asia/Tokyo");
+    expect(app.querySelector("#birth-zone").value).toBe(
+      "Asia / Tokyo · UTC+09:00",
+    );
+  });
+
+  it("keeps invalid zone text from replacing the selected canonical value", () => {
+    const start = vi.fn();
+    renderSetup(app, { start }, "1990-05-15T00:00", "Asia/Tokyo");
+    const zone = app.querySelector("#birth-zone");
+    zone.value = "not a zone";
+    zone.dispatchEvent(new Event("input", { bubbles: true }));
+    app
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(start).toHaveBeenCalledWith(
+      "1990-05-15T00:00",
+      "Asia/Tokyo",
+      null,
+      "world",
+    );
+    expect(zone.value).toBe("Asia / Tokyo · UTC+09:00");
+  });
+
+  it("selects an open zone result with Enter without submitting setup", () => {
+    const start = vi.fn();
+    renderSetup(app, { start }, null, "UTC");
+    app.querySelector("#birth-date").value = "1990-05-15";
+    const zone = app.querySelector("#birth-zone");
+    zone.value = "tokyo";
+    zone.dispatchEvent(new Event("input", { bubbles: true }));
+    const enter = keydown(zone, "Enter");
+    expect(enter.defaultPrevented).toBe(true);
+    expect(start).not.toHaveBeenCalled();
+
+    app
+      .querySelector("form")
+      .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    expect(start).toHaveBeenCalledWith(
+      "1990-05-15T00:00",
+      "Asia/Tokyo",
+      null,
+      "world",
+    );
   });
 
   it("offers an explicit actuarial baseline defaulting to World", () => {
@@ -198,13 +265,12 @@ describe("renderSetup", () => {
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "1980-07-08";
     app.querySelector("#birth-sex").value = "male";
-    const zone = app.querySelector("#birth-zone").value;
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
     expect(start).toHaveBeenCalledWith(
       "1980-07-08T00:00",
-      zone,
+      detectedZone,
       "male",
       "world",
     );
@@ -215,11 +281,15 @@ describe("renderSetup", () => {
     renderSetup(app, { start }, null);
     app.querySelector("#birth-date").value = "1980-07-08";
     app.querySelector("#birth-life-table").value = "us";
-    const zone = app.querySelector("#birth-zone").value;
     app
       .querySelector("form")
       .dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-    expect(start).toHaveBeenCalledWith("1980-07-08T00:00", zone, null, "us");
+    expect(start).toHaveBeenCalledWith(
+      "1980-07-08T00:00",
+      detectedZone,
+      null,
+      "us",
+    );
   });
 });
 
@@ -465,13 +535,32 @@ describe("renderSettings", () => {
     const a = actions();
     renderSettings(app, a, data({ birthZone: "Asia/Tokyo" }));
     const zone = app.querySelector("#settings-zone");
-    expect(zone.value).toBe("Asia/Tokyo");
-    const other = [...zone.options]
-      .map((o) => o.value)
-      .find((v) => v !== zone.value);
-    zone.value = other;
-    zone.dispatchEvent(new Event("change", { bubbles: true }));
-    expect(a.setZone).toHaveBeenCalledWith(other);
+    expect(zone.value).toBe("Asia / Tokyo · UTC+09:00");
+    zone.value = "new york";
+    zone.dispatchEvent(new Event("input", { bubbles: true }));
+    document.querySelector('[role="option"]').click();
+    expect(a.setZone).toHaveBeenCalledOnce();
+    expect(a.setZone).toHaveBeenCalledWith("America/New_York");
+  });
+
+  it("cleans up an open zone popup before settings re-render", () => {
+    const abort = vi.spyOn(AbortController.prototype, "abort");
+    renderSettings(app, actions(), data({ birthZone: "Asia/Tokyo" }));
+    const input = app.querySelector("#settings-zone");
+    keydown(input, "ArrowDown");
+    renderSettings(app, actions(), data({ birthZone: "Asia/Tokyo" }));
+    expect(abort).toHaveBeenCalledOnce();
+    expect(document.querySelectorAll(".search-select-popup")).toHaveLength(1);
+  });
+
+  it("keeps IANA options left-to-right in an RTL document", () => {
+    document.documentElement.dir = "rtl";
+    renderSettings(app, actions(), data({ birthZone: "Asia/Tokyo" }));
+    const input = app.querySelector("#settings-zone");
+    keydown(input, "ArrowDown");
+    expect(input.dir).toBe("ltr");
+    expect(document.querySelector(".search-select-popup").dir).toBe("rtl");
+    expect(document.querySelector('[role="option"]').dir).toBe("ltr");
   });
 
   it("wires the data export and import buttons", () => {


### PR DESCRIPTION
## Summary

- replace the setup and Settings IANA selects with one reusable, dependency-free searchable combobox
- show human-readable canonical zones with their current UTC offsets while preserving the stored IANA ID
- keep the popup in the top layer (with a fixed-position fallback) so scrolling settings cannot clip it

## UX and accessibility

- implements the WAI-ARIA editable combobox/listbox pattern with stable selected values separate from query text
- supports Arrow Up/Down, Home/End, Enter, Escape, Tab, typing, pointer/touch selection, light dismiss, IME composition, and active-option scrolling
- restores the selected label after invalid free text and leaves closed Enter to normal form submission
- preserves 44px touch targets, reduced-motion behavior, native field styling, RTL bidi isolation, and 320px reflow without horizontal overflow

## Internationalization

- adds translated search and empty-result strings to all 55 WebExtension locale catalogs
- keeps exact catalog/placeholder parity with the English runtime fallback

## Validation

- 338 tests pass, including generic filtering/state, offsets/DST/fallbacks, ARIA and keyboard paths, setup submission, settings persistence, RTL, and cleanup
- Prettier, changed-file syntax checks, packaging, and the bundled Impeccable detector pass
- the packaged archive contains all 55 locale catalogs