### PR TITLE
Add one-click integrated browser preview

### DIFF
--- a/.github/copilot-desktop.yml
+++ b/.github/copilot-desktop.yml
@@ -1,0 +1,4 @@
+scripts:
+  run: npm run dev
+server_ready_pattern: '(?i)ready at (https?://\S+)'
+auto_open_in_browser: true

--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ The shipped extension has **no build step and no runtime dependencies** — the
 files in [`src/`](src/) _are_ the extension. Development tooling (formatting and
 tests) runs through npm and never ships; `npm run zip` only packages `src/`.
 
+### Preview in the Copilot app
+
+Click **Run** to start the local preview and open it in the integrated browser.
+The preview serves `src/tab.html`, starting at `http://127.0.0.1:4173/` and
+automatically choosing the next available port when another session is running.
+Settings use the same local-storage fallback as any ordinary HTTP preview.
+
+To start it from a terminal instead:
+
+```
+npm run dev
+```
+
 ### Run it locally
 
 Load the `src/` folder as an unpacked extension:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "A browser extension that replaces the new tab page with a live counter of your age.",
   "license": "MIT",
   "scripts": {
+    "start": "node scripts/preview.mjs",
+    "dev": "node scripts/preview.mjs",
     "zip": "bash scripts/pack.sh",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -26,6 +26,9 @@ const contentTypes = {
 function respond(response, status, body, headers = {}) {
   response.writeHead(status, {
     "cache-control": "no-store",
+    ...(typeof body === "string"
+      ? { "content-type": "text/plain; charset=utf-8" }
+      : {}),
     ...headers,
   });
   response.end(body);

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -23,7 +23,7 @@ const contentTypes = {
   ".txt": "text/plain; charset=utf-8",
 };
 
-function respond(response, status, body, headers = {}) {
+function respond(request, response, status, body, headers = {}) {
   response.writeHead(status, {
     "cache-control": "no-store",
     ...(typeof body === "string"
@@ -31,12 +31,14 @@ function respond(response, status, body, headers = {}) {
       : {}),
     ...headers,
   });
-  response.end(body);
+  response.end(request.method === "HEAD" ? undefined : body);
 }
 
 const server = createServer(async (request, response) => {
   if (request.method !== "GET" && request.method !== "HEAD") {
-    respond(response, 405, "Method not allowed", { allow: "GET, HEAD" });
+    respond(request, response, 405, "Method not allowed", {
+      allow: "GET, HEAD",
+    });
     return;
   }
 
@@ -47,7 +49,7 @@ const server = createServer(async (request, response) => {
     );
   } catch (error) {
     console.error("Invalid preview request URL:", error);
-    respond(response, 400, "Bad request");
+    respond(request, response, 400, "Bad request");
     return;
   }
 
@@ -55,7 +57,7 @@ const server = createServer(async (request, response) => {
     pathname === "/" ? "tab.html" : pathname.replace(/^\/+/, "");
   const filePath = resolve(root, relativePath);
   if (filePath !== root && !filePath.startsWith(`${root}${sep}`)) {
-    respond(response, 403, "Forbidden");
+    respond(request, response, 403, "Forbidden");
     return;
   }
 
@@ -64,16 +66,16 @@ const server = createServer(async (request, response) => {
     const contentType =
       contentTypes[extname(filePath).toLowerCase()] ||
       "application/octet-stream";
-    respond(response, 200, request.method === "HEAD" ? undefined : body, {
+    respond(request, response, 200, body, {
       "content-type": contentType,
     });
   } catch (error) {
     if (error?.code === "ENOENT" || error?.code === "EISDIR") {
-      respond(response, 404, "Not found");
+      respond(request, response, 404, "Not found");
       return;
     }
     console.error(`Could not serve ${pathname}:`, error);
-    respond(response, 500, "Internal server error");
+    respond(request, response, 500, "Internal server error");
   }
 });
 
@@ -95,7 +97,8 @@ server.on("listening", () => {
   const address = server.address();
   const activePort =
     typeof address === "object" && address ? address.port : port;
-  console.log(`Mortality preview ready at http://${host}:${activePort}/`);
+  const urlHost = host.includes(":") ? `[${host}]` : host;
+  console.log(`Mortality preview ready at http://${urlHost}:${activePort}/`);
 });
 
 server.listen(port, host);

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -97,7 +97,12 @@ server.on("listening", () => {
   const address = server.address();
   const activePort =
     typeof address === "object" && address ? address.port : port;
-  const urlHost = host.includes(":") ? `[${host}]` : host;
+  const urlHost =
+    host === "0.0.0.0" || host === "::"
+      ? "localhost"
+      : host.includes(":")
+        ? `[${host}]`
+        : host;
   console.log(`Mortality preview ready at http://${urlHost}:${activePort}/`);
 });
 

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -24,11 +24,18 @@ const contentTypes = {
 };
 
 function respond(request, response, status, body, headers = {}) {
+  const contentLength =
+    typeof body === "string"
+      ? Buffer.byteLength(body)
+      : Buffer.isBuffer(body)
+        ? body.length
+        : undefined;
   response.writeHead(status, {
     "cache-control": "no-store",
     ...(typeof body === "string"
       ? { "content-type": "text/plain; charset=utf-8" }
       : {}),
+    ...(contentLength === undefined ? {} : { "content-length": contentLength }),
     ...headers,
   });
   response.end(request.method === "HEAD" ? undefined : body);
@@ -110,6 +117,10 @@ server.listen(port, host);
 
 for (const signal of ["SIGINT", "SIGTERM"]) {
   process.once(signal, () => {
-    server.close(() => process.exit(0));
+    if (server.listening) {
+      server.close(() => process.exit(0));
+    } else {
+      process.exit(0);
+    }
   });
 }

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -6,8 +6,8 @@ import { fileURLToPath } from "node:url";
 const root = resolve(fileURLToPath(new URL("../src/", import.meta.url)));
 const host = process.env.HOST || "127.0.0.1";
 const defaultPort = 4173;
-const configuredPort = process.env.PORT;
-let port = Number(configuredPort || defaultPort);
+const configuredPort = process.env.PORT?.trim() || undefined;
+let port = Number(configuredPort ?? defaultPort);
 
 if (!Number.isInteger(port) || port < 0 || port > 65535) {
   throw new RangeError(`Invalid PORT: ${process.env.PORT}`);

--- a/scripts/preview.mjs
+++ b/scripts/preview.mjs
@@ -1,0 +1,104 @@
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { extname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(fileURLToPath(new URL("../src/", import.meta.url)));
+const host = process.env.HOST || "127.0.0.1";
+const defaultPort = 4173;
+const configuredPort = process.env.PORT;
+let port = Number(configuredPort || defaultPort);
+
+if (!Number.isInteger(port) || port < 0 || port > 65535) {
+  throw new RangeError(`Invalid PORT: ${process.env.PORT}`);
+}
+
+const contentTypes = {
+  ".css": "text/css; charset=utf-8",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain; charset=utf-8",
+};
+
+function respond(response, status, body, headers = {}) {
+  response.writeHead(status, {
+    "cache-control": "no-store",
+    ...headers,
+  });
+  response.end(body);
+}
+
+const server = createServer(async (request, response) => {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    respond(response, 405, "Method not allowed", { allow: "GET, HEAD" });
+    return;
+  }
+
+  let pathname;
+  try {
+    pathname = decodeURIComponent(
+      new URL(request.url || "/", "http://localhost").pathname,
+    );
+  } catch (error) {
+    console.error("Invalid preview request URL:", error);
+    respond(response, 400, "Bad request");
+    return;
+  }
+
+  const relativePath =
+    pathname === "/" ? "tab.html" : pathname.replace(/^\/+/, "");
+  const filePath = resolve(root, relativePath);
+  if (filePath !== root && !filePath.startsWith(`${root}${sep}`)) {
+    respond(response, 403, "Forbidden");
+    return;
+  }
+
+  try {
+    const body = await readFile(filePath);
+    const contentType =
+      contentTypes[extname(filePath).toLowerCase()] ||
+      "application/octet-stream";
+    respond(response, 200, request.method === "HEAD" ? undefined : body, {
+      "content-type": contentType,
+    });
+  } catch (error) {
+    if (error?.code === "ENOENT" || error?.code === "EISDIR") {
+      respond(response, 404, "Not found");
+      return;
+    }
+    console.error(`Could not serve ${pathname}:`, error);
+    respond(response, 500, "Internal server error");
+  }
+});
+
+server.on("error", (error) => {
+  if (
+    error?.code === "EADDRINUSE" &&
+    configuredPort === undefined &&
+    port < defaultPort + 100
+  ) {
+    port += 1;
+    server.listen(port, host);
+    return;
+  }
+  console.error("Could not start the Mortality preview:", error);
+  process.exitCode = 1;
+});
+
+server.on("listening", () => {
+  const address = server.address();
+  const activePort =
+    typeof address === "object" && address ? address.port : port;
+  console.log(`Mortality preview ready at http://${host}:${activePort}/`);
+});
+
+server.listen(port, host);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    server.close(() => process.exit(0));
+  });
+}


### PR DESCRIPTION
## Summary
- add a zero-dependency Node preview server for the extension source
- configure the Copilot app Run button to open the preview automatically
- select the next available localhost port for parallel worktree sessions
- document the equivalent `npm run dev` workflow

## Testing
- `npm test`
- `npm run format:check`
- `npm run zip`