### PR TITLE
Add age labels to the life-in-weeks grid

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -287,12 +287,14 @@ never a bounce, never a glow-for-flavor.
 
 ### Life in Weeks (view)
 
-- A full-screen calendar where each row is a year and each cell a week: a 52-column grid of
-  `1px`-radius (`rounded.2xs` hairline) squares with `aspect-ratio: 1` and `2px` gaps, in
-  three tonal states — lived (`count`-tinted), now (accent), future (translucent muted). The
-  legend swatches share the same hairline radius. The `2xs` (`1px`) corner just softens the
-  hard edge across the ~4,000-cell field without rounding the cells into dots — anything
-  larger reads as chips and breaks the plotted-grid feel.
+- A full-screen plotted field of sequential seven-day cells in fixed 52-column bands. A
+  narrow logical-start gutter labels every five bands, with decades strongest and only
+  decades visible on narrow screens. The labels remain subordinate and do not imply that a
+  52-week boundary is an exact birthday.
+- Cells keep the `1px`-radius (`rounded.2xs` hairline), `aspect-ratio: 1`, and three tonal
+  states — lived (`count`-tinted), now (accent), future (translucent muted). The current cell
+  is the only accent and carries a static outline. The legend swatches share the plot
+  vocabulary.
 
 ## 6. Do's and Don'ts
 

--- a/src/life-grid.js
+++ b/src/life-grid.js
@@ -1,0 +1,29 @@
+export const WEEKS_PER_ROW = 52;
+
+/**
+ * Describe fixed 52-cell visual bands without implying that their boundaries
+ * are exact calendar birthdays.
+ */
+export function lifeGridRows(total, columns = WEEKS_PER_ROW) {
+  if (!Number.isInteger(total) || total < 0) {
+    throw new RangeError("Life-grid total must be a non-negative integer");
+  }
+  if (!Number.isInteger(columns) || columns < 1) {
+    throw new RangeError("Life-grid columns must be a positive integer");
+  }
+
+  const rows = [];
+  for (let startIndex = 0, age = 0; startIndex < total; age++) {
+    const cellCount = Math.min(columns, total - startIndex);
+    rows.push({
+      age,
+      startIndex,
+      endIndex: startIndex + cellCount - 1,
+      cellCount,
+      isDecade: age % 10 === 0,
+      showLabel: age % 5 === 0,
+    });
+    startIndex += cellCount;
+  }
+  return rows;
+}

--- a/src/tab.css
+++ b/src/tab.css
@@ -876,9 +876,8 @@ footer {
   }
 }
 
-/* Life in weeks: a full-screen calendar where each row is a year and each cell a
-   week. Taller than the viewport, so the screen scrolls from the top instead of
-   the base centred layout (which would clip the grid). */
+/* Life in weeks: sequential seven-day cells in fixed 52-cell bands, with a
+   restrained age gutter that does not imply an exact birthday boundary. */
 body.screen-weeks {
   justify-content: flex-start;
   height: auto;
@@ -893,6 +892,7 @@ body.screen-weeks {
   align-items: center;
   gap: 0.9rem;
   padding: 1.25rem;
+  width: 100%;
 }
 
 .weeks-head {
@@ -903,28 +903,59 @@ body.screen-weeks {
   text-align: center;
 }
 
-.weeks-grid {
-  display: grid;
-  grid-template-columns: repeat(52, 1fr);
+.weeks-plot {
+  display: flex;
+  flex-direction: column;
   gap: 2px;
-  width: min(92vw, 620px);
+  width: min(96vw, 660px);
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
 }
 
-.weeks-grid i {
+.weeks-row {
+  display: grid;
+  grid-template-columns: 1.6rem minmax(0, 620px);
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.weeks-band {
+  display: grid;
+  grid-template-columns: repeat(52, minmax(0, 1fr));
+  gap: clamp(1px, 0.3vw, 2px);
+  min-width: 0;
+}
+
+.age-tick {
+  color: color-mix(in srgb, var(--label) 66%, transparent);
+  font-size: 0.58rem;
+  line-height: 1;
+  text-align: end;
+}
+
+.age-tick.decade-label {
+  color: var(--label);
+  font-weight: 600;
+}
+
+.weeks-band i {
+  position: relative;
   aspect-ratio: 1/1;
   border-radius: 1px;
 }
 
-.weeks-grid i.lived {
+.weeks-band i.lived {
   background: color-mix(in srgb, var(--count) 62%, var(--bg));
 }
 
-.weeks-grid i.now {
+.weeks-band i.now {
   background: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+  z-index: 1;
 }
 
-.weeks-grid i.future {
+.weeks-band i.future {
   background: color-mix(in srgb, var(--label) 20%, transparent);
 }
 
@@ -944,6 +975,7 @@ body.screen-weeks {
 }
 
 .weeks-legend i {
+  position: relative;
   width: 0.62rem;
   height: 0.62rem;
   border-radius: 1px;
@@ -959,6 +991,25 @@ body.screen-weeks {
 
 .weeks-legend i.future {
   background: color-mix(in srgb, var(--label) 20%, transparent);
+}
+
+@media (max-width: 360px) {
+  .weeks-wrap {
+    padding-inline: 0.75rem;
+  }
+
+  .weeks-plot {
+    width: 100%;
+  }
+
+  .weeks-row {
+    grid-template-columns: 1.25rem minmax(0, 1fr);
+    gap: 0.3rem;
+  }
+
+  .age-tick.five-year-label {
+    visibility: hidden;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/views.js
+++ b/src/views.js
@@ -20,6 +20,7 @@ import {
   msg,
   normalizeLanguage,
 } from "./i18n.js";
+import { lifeGridRows } from "./life-grid.js";
 import { createSearchSelect } from "./search-select.js";
 
 const COLOR_LABELS = {
@@ -733,9 +734,8 @@ export function renderSettings(
 }
 
 /**
- * Life-in-weeks grid: every row is a year of the expectancy, every cell a week —
- * lived weeks filled, the current week accented, the rest dim. Static per open;
- * the grid is decorative (aria-hidden) and the subtitle carries the real counts.
+ * Life-in-weeks plot: fixed 52-cell bands with quiet age ticks and one accented
+ * current cell. The plot stays decorative; the subtitle carries the real counts.
  */
 export function renderWeeks(
   app,
@@ -764,13 +764,49 @@ export function renderWeeks(
     gearIcon(),
   );
 
-  const grid = el("div", { class: "weeks-grid", "aria-hidden": "true" });
-  const cells = document.createDocumentFragment();
-  for (let i = 0; i < total; i++) {
-    const cls = i < lived ? "lived" : i === lived ? "now" : "future";
-    cells.append(el("i", { class: cls }));
+  const plot = el("div", { class: "weeks-plot", "aria-hidden": "true" });
+  const rows = document.createDocumentFragment();
+
+  for (const row of lifeGridRows(total)) {
+    const band = el("div", { class: "weeks-band" });
+    const cells = document.createDocumentFragment();
+    for (let offset = 0; offset < row.cellCount; offset++) {
+      const index = row.startIndex + offset;
+      const state =
+        index < lived ? "lived" : index === lived ? "now" : "future";
+      const cell = document.createElement("i");
+      cell.className = state;
+      cells.append(cell);
+    }
+    band.append(cells);
+
+    const cadenceClass = row.isDecade
+      ? " decade-label"
+      : row.showLabel
+        ? " five-year-label"
+        : "";
+    const age = formatNumber(row.age);
+    rows.append(
+      el(
+        "div",
+        {
+          class: `weeks-row${row.isDecade ? " decade-row" : ""}`,
+          "data-age": row.age,
+        },
+        [
+          el(
+            "span",
+            {
+              class: `age-tick${cadenceClass}`,
+            },
+            row.showLabel ? age : "",
+          ),
+          band,
+        ],
+      ),
+    );
   }
-  grid.append(cells);
+  plot.append(rows);
 
   const wrap = el("div", { class: "weeks-wrap" }, [
     el("div", { class: "weeks-head" }, [
@@ -785,7 +821,7 @@ export function renderWeeks(
         ]),
       ),
     ]),
-    grid,
+    plot,
     el("div", { class: "weeks-legend" }, [
       el("span", {}, [el("i", { class: "lived" }), msg("legendLived")]),
       el("span", {}, [el("i", { class: "now" }), msg("legendThisWeek")]),

--- a/test/life-grid.test.js
+++ b/test/life-grid.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { lifeGridRows } from "../src/life-grid.js";
+
+describe("lifeGridRows", () => {
+  it("returns no rows for an empty grid", () => {
+    expect(lifeGridRows(0)).toEqual([]);
+  });
+
+  it("describes full, partial, and final 52-cell rows", () => {
+    expect(lifeGridRows(105)).toEqual([
+      {
+        age: 0,
+        startIndex: 0,
+        endIndex: 51,
+        cellCount: 52,
+        isDecade: true,
+        showLabel: true,
+      },
+      {
+        age: 1,
+        startIndex: 52,
+        endIndex: 103,
+        cellCount: 52,
+        isDecade: false,
+        showLabel: false,
+      },
+      {
+        age: 2,
+        startIndex: 104,
+        endIndex: 104,
+        cellCount: 1,
+        isDecade: false,
+        showLabel: false,
+      },
+    ]);
+  });
+
+  it("marks five-year and decade label cadence", () => {
+    const rows = lifeGridRows(11 * 52);
+    expect(rows[0].isDecade).toBe(true);
+    expect(rows[5].showLabel).toBe(true);
+    expect(rows[5].isDecade).toBe(false);
+    expect(rows[10].showLabel).toBe(true);
+    expect(rows[10].isDecade).toBe(true);
+  });
+
+  it("rejects malformed bounds", () => {
+    expect(() => lifeGridRows(-1)).toThrow(RangeError);
+    expect(() => lifeGridRows(52.5)).toThrow(RangeError);
+    expect(() => lifeGridRows(52, 0)).toThrow(RangeError);
+  });
+});

--- a/test/tab.integration.test.js
+++ b/test/tab.integration.test.js
@@ -775,11 +775,13 @@ describe("life in weeks", () => {
     const bornMs = new Date("2000-01-01T00:00").getTime();
     const lived = Math.floor((Date.now() - bornMs) / WEEK_MS);
 
-    const grid = document.querySelector(".weeks-grid");
-    expect(grid.querySelectorAll("i").length).toBe(total);
+    const grid = document.querySelector(".weeks-plot");
+    expect(grid.querySelectorAll(".weeks-row")).toHaveLength(80);
+    expect(grid.querySelectorAll(".weeks-band i").length).toBe(total);
     expect(grid.querySelectorAll("i.lived").length).toBe(lived);
     expect(grid.querySelectorAll("i.now").length).toBe(1);
     expect(grid.querySelectorAll("i.future").length).toBe(total - lived - 1);
+    expect(grid.querySelectorAll("[tabindex]")).toHaveLength(0);
 
     document.querySelector('[aria-label="Back"]').click();
     expect(document.body.className).toBe("screen-counter");

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
-import { renderSetup, renderCounter, renderSettings } from "../src/views.js";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  renderSetup,
+  renderCounter,
+  renderSettings,
+  renderWeeks,
+} from "../src/views.js";
 import { THEME_KEYS, PRESETS, cssDefault } from "../src/store.js";
 import { detectZone } from "../src/time.js";
 import { SUPPORTED_LANGUAGES } from "../src/i18n.js";
@@ -10,6 +15,10 @@ beforeEach(() => {
   app = document.createElement("div");
   app.id = "app";
   document.body.appendChild(app);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 function keydown(el, key) {
@@ -397,6 +406,70 @@ describe("renderCounter", () => {
     const hint = app.querySelector(".unit-hint");
     expect(hint).not.toBeNull();
     expect(hint.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("renderWeeks", () => {
+  const actions = { back: vi.fn(), openSettings: vi.fn() };
+
+  function render(overrides = {}) {
+    renderWeeks(app, actions, {
+      born: "Born 1 January 2000",
+      lived: 53,
+      total: 104,
+      expectancy: 2,
+      ...overrides,
+    });
+  }
+
+  it("renders fixed 52-cell rows with the expected state classes", () => {
+    render();
+    expect(app.querySelectorAll(".weeks-row")).toHaveLength(2);
+    expect(app.querySelectorAll(".weeks-band i")).toHaveLength(104);
+    expect(app.querySelectorAll(".weeks-band i.lived")).toHaveLength(53);
+    expect(app.querySelectorAll(".weeks-band i.now")).toHaveLength(1);
+    expect(app.querySelectorAll(".weeks-band i.future")).toHaveLength(50);
+  });
+
+  it("shows five-year labels with stronger decade metadata", () => {
+    render({ total: 11 * 52, lived: 100 });
+    expect(app.querySelector('[data-age="0"] .age-tick').classList).toContain(
+      "decade-label",
+    );
+    expect(app.querySelector('[data-age="5"] .age-tick').textContent).toBe("5");
+    expect(app.querySelector('[data-age="10"]').classList).toContain(
+      "decade-row",
+    );
+    expect(app.querySelector('[data-age="10"] .age-tick').classList).toContain(
+      "decade-label",
+    );
+  });
+
+  it("keeps the decorative plot out of the tab order", () => {
+    render();
+    expect(app.querySelector(".weeks-plot").getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+    expect(app.querySelectorAll("[tabindex]")).toHaveLength(0);
+  });
+
+  it("keeps exactly one accent current cell", () => {
+    render({ lived: 10 });
+    expect(app.querySelectorAll(".weeks-band i.now")).toHaveLength(1);
+  });
+
+  it("uses RTL flow and localized age digits", () => {
+    document.documentElement.dir = "rtl";
+    vi.stubGlobal("chrome", {
+      i18n: {
+        getUILanguage: () => "ar",
+        getMessage: () => "",
+      },
+    });
+    render();
+
+    expect(document.documentElement.dir).toBe("rtl");
+    expect(app.querySelector('[data-age="0"] .age-tick').textContent).toBe("٠");
   });
 });
 


### PR DESCRIPTION
## Summary

- organize the life-in-weeks plot into fixed 52-cell visual bands while keeping every cell a sequential real seven-day period
- add a narrow logical-start age gutter with five-year labels, stronger decade labels, and decade-only labels on narrow screens
- strengthen the single static current-week marker while keeping it as the only accent

## Design

The grid stays a quiet plotted field: no cards, milestones, badges, dividers, animation, or per-cell interaction. Age markings remain subordinate to the weeks, and the existing lived/current/ahead legend is unchanged.

## Stack

Layer 2, #61, merged while this PR was in review. This branch now contains one age-grid commit directly on the merged `main` tip `f9585d0d97f52ae7ae7693e479542f1d2266f60a`; no ancestry bridge remains.

## Verification

- 374 Vitest tests
- Prettier and `node --check`
- extension package inspection; 55 locale catalogs remain at 91-key parity
- Chrome 150 at 1280px, a 640px CSS viewport representing 200% desktop zoom, and 320px Arabic RTL/German: no horizontal overflow, no band borders, no milestone elements, one current accent, zero focusable grid cells
- 4,160-cell render: 30.28 ms median versus 26.48 ms on merged main (+3.80 ms)
- impeccable design detector
- Prettier, Vitest, Pack, both Analyze jobs, and CodeQL green