### PR TITLE
Release v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mortality",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mortality",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mortality",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "A browser extension that replaces the new tab page with a live counter of your age.",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "permissions": ["storage"],


### PR DESCRIPTION
## Summary

- bump `src/manifest.json`, `package.json`, and `package-lock.json` to `1.6.0`
- prepare the changes since `v1.5.0`, including privacy-respecting device sync, for release

## Release checks

- 474 tests passing
- Prettier check passing
- `mortality-v1.6.0.zip` packages successfully with the expected manifest version

## Store status

Chrome and Firefox can accept the new submission. Edge still has the previously submitted `v1.4.0` under certification, so its `v1.6.0` submission may need to be retried after that review completes.