### PR TITLE
Replace stale Chrome review submissions

### DIFF
--- a/.github/skills/publish-to-stores/SKILL.md
+++ b/.github/skills/publish-to-stores/SKILL.md
@@ -23,8 +23,8 @@ Ships a tagged release to all three extension stores. All credentials live in
 
 ## How publishing works
 
-- **Chrome** — Web Store API v2: refresh an access token, upload the package,
-  then `:publish`.
+- **Chrome** — Web Store API v2: refresh an access token, replace an older
+  pending review when necessary, upload the package, then `:publish`.
 - **Edge** — Add-ons API v1.1: upload the package, poll, publish the draft,
   poll again.
 - **Firefox** — the exact `web-ext` version locked in `package-lock.json` runs

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -87,6 +87,91 @@ request() {
 # ---------------------------------------------------------------------------
 # Chrome Web Store  (v2 REST API)
 # ---------------------------------------------------------------------------
+chrome_wait_cancelled() {
+  local status_url="$1" token="$2"
+  local i body state
+
+  for i in $(seq 1 12); do
+    request GET "$status_url" -H "Authorization: Bearer $token" \
+      || die "Chrome: submission status failed (HTTP $http_code): $response_body"
+    body="$response_body"
+    state="$(printf '%s' "$body" | jq -er \
+      '.submittedItemRevisionStatus.state // "" | select(type == "string")')" \
+      || die "Chrome: submission status response omitted state: $body"
+    [ "$state" != "PENDING_REVIEW" ] && return 0
+    [ "$i" -lt 12 ] || break
+    printf '    Chrome: cancellation pending...\n'
+    sleep 5
+  done
+
+  die "Chrome: timed out waiting for pending submission cancellation"
+}
+
+chrome_prepare_submission() {
+  local api="$1" item="$2" token="$3"
+  local body state pending_version version_order
+  local target_version="${VERSION#v}"
+  local status_url="$api/v2/$item:fetchStatus"
+
+  request GET "$status_url" -H "Authorization: Bearer $token" \
+    || die "Chrome: submission status failed (HTTP $http_code): $response_body"
+  body="$response_body"
+  state="$(printf '%s' "$body" | jq -er \
+    '.submittedItemRevisionStatus.state // "" | select(type == "string")')" \
+    || die "Chrome: submission status response omitted state: $body"
+  [ "$state" = "PENDING_REVIEW" ] || return 0
+
+  pending_version="$(printf '%s' "$body" | jq -er '
+    [
+      .submittedItemRevisionStatus.distributionChannels[]?.crxVersion
+      | select(type == "string" and length > 0)
+    ]
+    | unique
+    | if length == 1 then .[0] else empty end
+  ')" || die "Chrome: pending submission omitted a unique version: $body"
+
+  version_order="$(jq -enr --arg target "$target_version" --arg pending "$pending_version" '
+    def parts:
+      if test("^[0-9]+(\\.[0-9]+){0,3}$") then
+        (split(".") | map(tonumber) + [0, 0, 0, 0])[:4]
+      else
+        error("invalid extension version")
+      end;
+    ($target | parts) as $target_parts
+    | ($pending | parts) as $pending_parts
+    | if $target_parts == $pending_parts then 0
+      elif $target_parts > $pending_parts then 1
+      else -1
+      end
+  ')" || die "Chrome: could not compare versions '$VERSION' and '$pending_version'"
+
+  case "$version_order" in
+    0)
+      ok "Chrome: $VERSION is already pending review"
+      chrome_submission_action=skip
+      ;;
+    1)
+      if $DRY_RUN; then
+        warn "Chrome: --dry-run, would replace pending $pending_version with $VERSION"
+        chrome_submission_action=skip
+        return
+      fi
+      log "Chrome: cancelling pending $pending_version submission before $VERSION"
+      request POST "$api/v2/$item:cancelSubmission" \
+        -H "Authorization: Bearer $token" -H "Content-Length: 0" \
+        || die "Chrome: cancel submission failed (HTTP $http_code): $response_body"
+      chrome_wait_cancelled "$status_url" "$token"
+      ok "Chrome: cancelled pending $pending_version submission"
+      ;;
+    -1)
+      die "Chrome: pending version $pending_version is newer than target $VERSION"
+      ;;
+    *)
+      die "Chrome: unexpected version comparison result '$version_order'"
+      ;;
+  esac
+}
+
 publish_chrome() {
   require_env "${chrome_vars[@]}"
   log "${c_bold}Chrome Web Store${c_reset}"
@@ -105,6 +190,10 @@ publish_chrome() {
 
   local api="https://chromewebstore.googleapis.com"
   local item="publishers/$CHROME_PUBLISHER_ID/items/$CHROME_EXTENSION_ID"
+
+  chrome_submission_action=upload
+  chrome_prepare_submission "$api" "$item" "$token"
+  [ "$chrome_submission_action" = "upload" ] || return 0
 
   log "Chrome: uploading package"
   request POST "$api/upload/v2/$item:upload" \

--- a/test/publish.test.js
+++ b/test/publish.test.js
@@ -57,7 +57,7 @@ function runPublisher(store, responses, { dryRun = false } = {}) {
 
   const queue = join(temp, "responses.json");
   const index = join(temp, "curl-index");
-  const zip = join(temp, "mortality-9.9.9.zip");
+  const zip = join(temp, "mortality-v9.9.9.zip");
   writeFileSync(queue, JSON.stringify(responses));
   writeFileSync(zip, "fixture");
 
@@ -96,6 +96,14 @@ function tokenResponse(code = 200) {
   };
 }
 
+function chromeStatusResponse(status = {}) {
+  return {
+    code: 200,
+    body: JSON.stringify(status),
+    expect: [":fetchStatus", "-X GET"],
+  };
+}
+
 beforeEach(() => {
   temp = mkdtempSync(join(tmpdir(), "mortality-publish-"));
 });
@@ -108,6 +116,7 @@ describe("Chrome publishing", () => {
   it("polls asynchronous uploads before publishing and reports the API state", () => {
     const result = runPublisher("chrome", [
       tokenResponse(),
+      chromeStatusResponse(),
       {
         code: 200,
         body: '{"uploadState":"IN_PROGRESS"}',
@@ -131,7 +140,7 @@ describe("Chrome publishing", () => {
     ]);
 
     expect(result.status, result.output).toBe(0);
-    expect(result.calls).toBe(5);
+    expect(result.calls).toBe(6);
     expect(result.output).toContain("Chrome: package accepted");
     expect(result.output).toContain("state=PENDING_REVIEW");
     expect(result.output).not.toContain("Publishing to: chrome (dry-run)");
@@ -140,12 +149,16 @@ describe("Chrome publishing", () => {
   it("labels dry runs accurately and stops after a successful upload", () => {
     const result = runPublisher(
       "chrome",
-      [tokenResponse(), { code: 200, body: '{"uploadState":"SUCCEEDED"}' }],
+      [
+        tokenResponse(),
+        chromeStatusResponse(),
+        { code: 200, body: '{"uploadState":"SUCCEEDED"}' },
+      ],
       { dryRun: true },
     );
 
     expect(result.status, result.output).toBe(0);
-    expect(result.calls).toBe(2);
+    expect(result.calls).toBe(3);
     expect(result.output).toContain("Publishing to: chrome (dry-run)");
     expect(result.output).toContain("--dry-run, not publishing");
   });
@@ -169,6 +182,7 @@ describe("Chrome publishing", () => {
     (state) => {
       const result = runPublisher("chrome", [
         tokenResponse(),
+        chromeStatusResponse(),
         { code: 200, body: JSON.stringify({ uploadState: state }) },
       ]);
       expect(result.status).not.toBe(0);
@@ -190,6 +204,7 @@ describe("Chrome publishing", () => {
   ])("rejects the non-public publish state %s", (state) => {
     const result = runPublisher("chrome", [
       tokenResponse(),
+      chromeStatusResponse(),
       { code: 200, body: '{"uploadState":"SUCCEEDED"}' },
       { code: 200, body: JSON.stringify({ state }) },
     ]);
@@ -202,11 +217,80 @@ describe("Chrome publishing", () => {
   it("accepts an immediately published response", () => {
     const result = runPublisher("chrome", [
       tokenResponse(),
+      chromeStatusResponse(),
       { code: 200, body: '{"uploadState":"SUCCEEDED"}' },
       { code: 200, body: '{"state":"PUBLISHED"}' },
     ]);
     expect(result.status, result.output).toBe(0);
     expect(result.output).toContain("state=PUBLISHED");
+  });
+
+  it("replaces an older pending review before uploading the new release", () => {
+    const pending = {
+      submittedItemRevisionStatus: {
+        state: "PENDING_REVIEW",
+        distributionChannels: [{ crxVersion: "9.9.8" }],
+      },
+    };
+    const result = runPublisher("chrome", [
+      tokenResponse(),
+      chromeStatusResponse(pending),
+      {
+        code: 200,
+        body: "{}",
+        expect: [":cancelSubmission", "-X POST"],
+      },
+      chromeStatusResponse({
+        submittedItemRevisionStatus: { state: "CANCELLED" },
+      }),
+      { code: 200, body: '{"uploadState":"SUCCEEDED"}' },
+      { code: 200, body: '{"state":"PENDING_REVIEW"}' },
+    ]);
+
+    expect(result.status, result.output).toBe(0);
+    expect(result.calls).toBe(6);
+    expect(result.output).toContain(
+      "cancelling pending 9.9.8 submission before v9.9.9",
+    );
+    expect(result.output).toContain("submitted v9.9.9");
+  });
+
+  it("treats the requested version already pending review as success", () => {
+    const result = runPublisher("chrome", [
+      tokenResponse(),
+      chromeStatusResponse({
+        submittedItemRevisionStatus: {
+          state: "PENDING_REVIEW",
+          distributionChannels: [{ crxVersion: "9.9.9" }],
+        },
+      }),
+    ]);
+
+    expect(result.status, result.output).toBe(0);
+    expect(result.calls).toBe(2);
+    expect(result.output).toContain("v9.9.9 is already pending review");
+  });
+
+  it("does not replace a pending review during a dry run", () => {
+    const result = runPublisher(
+      "chrome",
+      [
+        tokenResponse(),
+        chromeStatusResponse({
+          submittedItemRevisionStatus: {
+            state: "PENDING_REVIEW",
+            distributionChannels: [{ crxVersion: "9.9.8" }],
+          },
+        }),
+      ],
+      { dryRun: true },
+    );
+
+    expect(result.status, result.output).toBe(0);
+    expect(result.calls).toBe(2);
+    expect(result.output).toContain(
+      "--dry-run, would replace pending 9.9.8 with v9.9.9",
+    );
   });
 });
 
@@ -244,7 +328,7 @@ describe("Edge publishing", () => {
 
     expect(result.status, result.output).toBe(0);
     expect(result.calls).toBe(5);
-    expect(result.output).toContain("Edge: published 9.9.9");
+    expect(result.output).toContain("Edge: published v9.9.9");
   });
 });
 


### PR DESCRIPTION
## Summary

- detect an older Chrome Web Store revision that is still pending review
- cancel only when the requested release is newer, then wait for cancellation before uploading
- treat an already-pending matching version as an idempotent success
- keep dry runs non-destructive and document the replacement behavior

## Context

The `v1.6.0` release reached GitHub, Edge, and Firefox, but Chrome rejected it because `v1.5.0` was still in review. Chrome Web Store API v2 exposes `fetchStatus` and `cancelSubmission` specifically for replacing a pending revision.

## Checks

- 477 tests passing
- Prettier check passing
- publisher shell syntax and package gate passing