### PR TITLE
Sync localized extension store summaries

### DIFF
--- a/src/_locales/am/messages.json
+++ b/src/_locales/am/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "አዲሱን ትር ገፅ በዕድሜ ቆጣሪ ይተካል",
+    "message": "እያንዳንዱን አዲስ ትር ዕድሜዎን በቀጥታ ወደሚቆጥር ቆጣሪ ይቀይሩት — ጊዜ እያለፈ መሆኑን የሚያስታውስ ጸጥ ያለ ማስታወሻ።",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "يستبدل صفحة علامة التبويب الجديدة بعدّاد لعمرك",
+    "message": "حوّل كل علامة تبويب جديدة إلى عدّاد مباشر لعمرك — تذكير هادئ بأن الوقت يمضي.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Заменя страницата на новия раздел с брояч на вашата възраст",
+    "message": "Превърнете всеки нов раздел в брояч на възрастта ви в реално време — тихо напомняне, че времето минава.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/bn/messages.json
+++ b/src/_locales/bn/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "নতুন ট্যাব পেজটিকে আপনার বয়সের একটি কাউন্টার দিয়ে প্রতিস্থাপন করে",
+    "message": "প্রতিটি নতুন ট্যাবকে আপনার বয়সের সরাসরি কাউন্টারে পরিণত করুন — সময় বয়ে যাচ্ছে, তার এক নীরব স্মারক।",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Substitueix la pàgina de pestanya nova pel comptador de la teva edat",
+    "message": "Converteix cada pestanya nova en un comptador en directe de la teva edat — un recordatori discret que el temps passa.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Nahradí stránku nové karty počítadlem vašeho věku",
+    "message": "Proměňte každou novou kartu v živé počítadlo svého věku — tichou připomínku, že čas plyne.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Udskifter siden for ny fane med en tæller for din alder",
+    "message": "Gør hver ny fane til en live-tæller for din alder — en stille påmindelse om, at tiden går.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Ersetzt die neue Tab-Seite durch einen Zähler deines Alters",
+    "message": "Mach jeden neuen Tab zu einem Live-Zähler deines Alters — eine stille Erinnerung daran, dass die Zeit vergeht.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Αντικαθιστά τη σελίδα νέας καρτέλας με έναν μετρητή της ηλικίας σου",
+    "message": "Μετέτρεψε κάθε νέα καρτέλα σε ζωντανό μετρητή της ηλικίας σου — μια ήρεμη υπενθύμιση ότι ο χρόνος περνά.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Replace new tab page with a counter of your age",
+    "message": "Turn every new tab into a live counter of your age — a quiet reminder that time is passing.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/en_AU/messages.json
+++ b/src/_locales/en_AU/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Replace new tab page with a counter of your age",
+    "message": "Turn every new tab into a live counter of your age — a quiet reminder that time is passing.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/en_GB/messages.json
+++ b/src/_locales/en_GB/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Replace new tab page with a counter of your age",
+    "message": "Turn every new tab into a live counter of your age — a quiet reminder that time is passing.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Replace new tab page with a counter of your age",
+    "message": "Turn every new tab into a live counter of your age — a quiet reminder that time is passing.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Sustituye la página de nueva pestaña por un contador de tu edad",
+    "message": "Convierte cada pestaña nueva en un contador en vivo de tu edad — un recordatorio sereno de que el tiempo pasa.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/es_419/messages.json
+++ b/src/_locales/es_419/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Reemplaza la página de pestaña nueva con un contador de tu edad",
+    "message": "Convierte cada pestaña nueva en un contador en vivo de tu edad — un recordatorio tranquilo de que el tiempo pasa.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/et/messages.json
+++ b/src/_locales/et/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Asendab uue vahekaardi lehe teie vanuse loendajaga",
+    "message": "Muuda iga uus vahekaart oma vanuse reaalajas loenduriks — vaikne meeldetuletus, et aeg möödub.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "صفحه‌ی برگه‌ی جدید را با شمارنده‌ی سن شما جایگزین می‌کند",
+    "message": "هر برگهٔ جدید را به شمارندهٔ زندهٔ سن خود تبدیل کنید — یادآوری آرامی که زمان در گذر است.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Korvaa uuden välilehden sivun ikäsi laskurilla",
+    "message": "Tee jokaisesta uudesta välilehdestä reaaliaikainen ikälaskuri — hiljainen muistutus ajan kulumisesta.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/fil/messages.json
+++ b/src/_locales/fil/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Pinapalitan ang bagong tab page ng isang counter ng iyong edad",
+    "message": "Gawing live na counter ng iyong edad ang bawat bagong tab — isang tahimik na paalala na lumilipas ang oras.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Remplace la page nouvel onglet par un compteur de votre âge",
+    "message": "Transformez chaque nouvel onglet en compteur d’âge en temps réel — un rappel discret que le temps passe.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/gu/messages.json
+++ b/src/_locales/gu/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "નવા ટેબ પેજને તમારી ઉંમરના કાઉન્ટરથી બદલે છે",
+    "message": "દરેક નવા ટૅબને તમારી ઉંમરના જીવંત કાઉન્ટરમાં ફેરવો — સમય પસાર થઈ રહ્યો છે તેનું શાંત સ્મરણ.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "מחליף את דף הכרטיסייה החדשה במונה של הגיל שלך",
+    "message": "הפכו כל כרטיסייה חדשה למונה חי של גילכם — תזכורת שקטה לכך שהזמן חולף.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "नए टैब के पेज को आपकी उम्र के काउंटर से बदल देता है",
+    "message": "हर नए टैब को अपनी उम्र के लाइव काउंटर में बदलें — समय बीतने की एक शांत याद।",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/hr/messages.json
+++ b/src/_locales/hr/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Zamjenjuje stranicu nove kartice brojačem vaše dobi",
+    "message": "Pretvorite svaku novu karticu u brojač svoje dobi uživo — tihi podsjetnik da vrijeme prolazi.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Az új lap oldalát az életkorod számlálójával helyettesíti",
+    "message": "Változtass minden új lapot életkorod élő számlálójává — csendes emlékeztetőül arra, hogy múlik az idő.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Mengganti halaman tab baru dengan penghitung usia Anda",
+    "message": "Ubah setiap tab baru menjadi penghitung usia Anda secara langsung — pengingat tenang bahwa waktu terus berlalu.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Sostituisce la pagina di nuova scheda con un contatore della tua età",
+    "message": "Trasforma ogni nuova scheda in un contatore in tempo reale della tua età — un discreto promemoria che il tempo passa.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "新しいタブページをあなたの年齢のカウンターに置き換えます",
+    "message": "すべての新しいタブを、あなたの年齢をリアルタイムで刻むカウンターに変えます — 時が流れていることを静かに思い出させます。",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/kn/messages.json
+++ b/src/_locales/kn/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "ಹೊಸ ಟ್ಯಾಬ್ ಪುಟವನ್ನು ನಿಮ್ಮ ವಯಸ್ಸಿನ ಕೌಂಟರ್‌ನೊಂದಿಗೆ ಬದಲಾಯಿಸುತ್ತದೆ",
+    "message": "ಪ್ರತಿ ಹೊಸ ಟ್ಯಾಬ್ ಅನ್ನು ನಿಮ್ಮ ವಯಸ್ಸಿನ ಲೈವ್ ಕೌಂಟರ್ ಆಗಿ ಬದಲಿಸಿ — ಸಮಯ ಸಾಗುತ್ತಿದೆ ಎಂಬ ಶಾಂತ ನೆನಪು.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "새 탭 페이지를 나이 카운터로 대체합니다",
+    "message": "새 탭을 열 때마다 나이를 실시간으로 세는 카운터로 바꾸세요. 시간이 흐르고 있음을 조용히 일깨워 줍니다.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/lt/messages.json
+++ b/src/_locales/lt/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Pakeičia naujo skirtuko puslapį jūsų amžiaus skaitikliu",
+    "message": "Paverskite kiekvieną naują skirtuką tiesioginiu savo amžiaus skaitikliu — tyliu priminimu, kad laikas bėga.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/lv/messages.json
+++ b/src/_locales/lv/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Aizstāj jaunas cilnes lapu ar jūsu vecuma skaitītāju",
+    "message": "Pārvērtiet katru jaunu cilni par sava vecuma skaitītāju reāllaikā — klusu atgādinājumu, ka laiks rit.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ml/messages.json
+++ b/src/_locales/ml/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "പുതിയ ടാബ് പേജിനെ നിങ്ങളുടെ പ്രായത്തിന്റെ ഒരു കൗണ്ടർ കൊണ്ട് മാറ്റുന്നു",
+    "message": "ഓരോ പുതിയ ടാബും നിങ്ങളുടെ പ്രായം തത്സമയം എണ്ണുന്ന കൗണ്ടറാക്കൂ — സമയം കടന്നുപോകുന്നുവെന്ന ശാന്തമായ ഓർമ്മപ്പെടുത്തൽ.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/mr/messages.json
+++ b/src/_locales/mr/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "नवीन टॅब पेज तुमच्या वयाच्या काउंटरने बदलतो",
+    "message": "प्रत्येक नवीन टॅबला तुमच्या वयाच्या लाइव्ह काउंटरमध्ये बदला — वेळ पुढे सरकत असल्याची एक शांत आठवण.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ms/messages.json
+++ b/src/_locales/ms/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Menggantikan halaman tab baharu dengan penghitung usia anda",
+    "message": "Jadikan setiap tab baharu penghitung langsung usia anda — peringatan tenang bahawa masa terus berlalu.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Vervangt de nieuw-tabbladpagina door een teller van je leeftijd",
+    "message": "Maak van elk nieuw tabblad een live teller van je leeftijd — een rustige herinnering dat de tijd verstrijkt.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Erstatter siden for ny fane med en teller for alderen din",
+    "message": "Gjør hver nye fane til en sanntidsteller for alderen din — en stille påminnelse om at tiden går.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Zamienia stronę nowej karty na licznik Twojego wieku",
+    "message": "Zmień każdą nową kartę w licznik wieku działający na żywo — spokojne przypomnienie, że czas płynie.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Substitui a página de nova guia por um contador da sua idade",
+    "message": "Transforme cada nova guia em um contador da sua idade em tempo real — um lembrete sereno de que o tempo passa.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/pt_PT/messages.json
+++ b/src/_locales/pt_PT/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Substitui a página de novo separador por um contador da tua idade",
+    "message": "Transforma cada novo separador num contador da tua idade em tempo real — um lembrete sereno de que o tempo passa.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Înlocuiește pagina filei noi cu un contor al vârstei tale",
+    "message": "Transformă fiecare filă nouă într-un contor live al vârstei tale — o amintire calmă că timpul trece.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Заменяет страницу новой вкладки счётчиком вашего возраста",
+    "message": "Превратите каждую новую вкладку в счётчик вашего возраста в реальном времени — спокойное напоминание, что время идёт.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/sk/messages.json
+++ b/src/_locales/sk/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Nahradí stránku nová karta počítadlom vášho veku",
+    "message": "Premeňte každú novú kartu na živé počítadlo svojho veku — tichú pripomienku, že čas plynie.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/sl/messages.json
+++ b/src/_locales/sl/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Nadomesti stran novega zavihka s števcem vaše starosti",
+    "message": "Spremenite vsak nov zavihek v števec svoje starosti v živo — tih opomnik, da čas teče.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Замењује страницу новог језичка бројачем ваших година",
+    "message": "Претворите сваки нови језичак у бројач својих година уживо — тихи подсетник да време пролази.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Ersätter sidan för nya flikar med en räknare för din ålder",
+    "message": "Gör varje ny flik till en liveräknare för din ålder — en stillsam påminnelse om att tiden går.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/sw/messages.json
+++ b/src/_locales/sw/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Inabadilisha ukurasa wa kichupo kipya na kihesabu cha umri wako",
+    "message": "Geuza kila kichupo kipya kuwa kihesabu cha moja kwa moja cha umri wako — ukumbusho tulivu kwamba muda unapita.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/ta/messages.json
+++ b/src/_locales/ta/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "புதிய தாவல் பக்கத்தை உங்கள் வயதின் எண்ணிக்கையாளருடன் மாற்றுகிறது",
+    "message": "ஒவ்வொரு புதிய தாவலையும் உங்கள் வயதை நேரலையில் கணக்கிடும் கவுண்டராக மாற்றுங்கள் — காலம் கடக்கிறது என்ற அமைதியான நினைவூட்டல்.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/te/messages.json
+++ b/src/_locales/te/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "కొత్త ట్యాబ్ పేజీని మీ వయసు కౌంటర్‌తో భర్తీ చేస్తుంది",
+    "message": "ప్రతి కొత్త ట్యాబ్‌ను మీ వయసును ప్రత్యక్షంగా లెక్కించే కౌంటర్‌గా మార్చండి — సమయం గడుస్తోందని నిశ్శబ్దంగా గుర్తుచేస్తుంది.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/th/messages.json
+++ b/src/_locales/th/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "แทนที่หน้าแท็บใหม่ด้วยตัวนับอายุของคุณ",
+    "message": "เปลี่ยนทุกแท็บใหม่ให้เป็นตัวนับอายุแบบเรียลไทม์ — เครื่องเตือนใจอย่างสงบว่าเวลากำลังผ่านไป",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Yeni sekme sayfasını yaşınızın sayacıyla değiştirir",
+    "message": "Her yeni sekmeyi yaşınızı canlı gösteren bir sayaca dönüştürün — zamanın geçtiğini hatırlatan sakin bir anımsatıcı.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Замінює сторінку нової вкладки на рахунок вашого віку",
+    "message": "Перетворіть кожну нову вкладку на лічильник вашого віку в реальному часі — тихе нагадування, що час минає.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "Thay thế trang tab mới bằng bộ đếm tuổi của bạn",
+    "message": "Biến mỗi tab mới thành bộ đếm tuổi theo thời gian thực — lời nhắc nhẹ nhàng rằng thời gian đang trôi.",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "将新标签页替换为你的年龄计数器",
+    "message": "让每个新标签页都成为实时显示你年龄的计数器——安静地提醒你，时间正在流逝。",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -4,7 +4,7 @@
     "description": "Extension name. Keep the product name unchanged."
   },
   "extDescription": {
-    "message": "將新分頁頁面替換為你的年齡計數器",
+    "message": "讓每個新分頁都成為即時顯示你年齡的計數器——安靜地提醒你，時間正在流逝。",
     "description": "Short extension-store description."
   },
   "pageTitle": {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -2,7 +2,8 @@
 
 export const EN_MESSAGES = {
   extName: "Mortality",
-  extDescription: "Replace new tab page with a counter of your age",
+  extDescription:
+    "Turn every new tab into a live counter of your age — a quiet reminder that time is passing.",
   pageTitle: "Mortality — New Tab",
   setupTitle: "When were you born?",
   setupSubtitle: "Your age, counting up live on every new tab.",

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -29,6 +29,7 @@ import { renderSetup } from "../src/views.js";
 import { formatBorn } from "../src/tab.js";
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const STORE_SUMMARY_MAX_LENGTH = 132;
 const LOCALES = [
   "ar",
   "am",
@@ -145,6 +146,10 @@ describe("locale catalogs", () => {
       expect(Object.keys(translated).sort()).toEqual(englishKeys);
       expect(translated.extName.message).toBe("Mortality");
       expect(translated.extDescription.message.trim()).not.toBe("");
+      expect(
+        [...translated.extDescription.message].length,
+        `${locale}.extDescription exceeds the store summary limit`,
+      ).toBeLessThanOrEqual(STORE_SUMMARY_MAX_LENGTH);
 
       for (const key of englishKeys) {
         expect(translated[key].message.trim(), `${locale}.${key}`).not.toBe("");


### PR DESCRIPTION
The package-provided store summary still used the older functional wording, leaving it out of sync with Mortality's current calm positioning. This updates the summary that Chrome and other package-aware stores read on the next release.

## Summary

- uses one canonical English message focused on the live age counter and quiet reminder
- carries the same meaning across all 55 supported locales
- keeps the production English fallback in parity with the locale catalog
- enforces the shared 132-character store limit in the localization tests

## Testing

- `npm test`
- `npm run format:check`
- `npm run zip`
- verified all 55 packaged locale catalogs exactly match their source files