### PR TITLE
Add Chromium extension smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,19 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  chromium:
+    name: "Chromium extension smoke"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:chromium
+
   pack:
     name: "Pack"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -95,9 +95,18 @@ npm run test:watch    # re-run on change
 npm run test:coverage # run with a coverage report
 ```
 
-CI runs formatting, the test suite, and a packaging smoke test on every pull
-request via the [`ci`](.github/workflows/ci.yml) workflow, which the release
-pipelines reuse so nothing ships without a green run.
+The real-browser smoke test loads `src/` as an unpacked extension in Playwright's
+pinned Chromium. Install that browser once, then run the test:
+
+```
+npx playwright install chromium
+npm run test:chromium
+```
+
+CI runs formatting, the Vitest suite, the Chromium extension smoke test, and a
+packaging smoke test on every pull request via the
+[`ci`](.github/workflows/ci.yml) workflow, which the release pipelines reuse so
+nothing ships without a green run.
 
 ### Package for the stores
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",
         "jsdom": "^29.1.1",
+        "playwright": "1.61.1",
         "prettier": "3.9.5",
         "vitest": "^4.1.10",
         "web-ext": "10.5.0"
@@ -4525,6 +4526,53 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "node scripts/preview.mjs",
     "zip": "bash scripts/pack.sh",
     "test": "vitest run",
+    "test:chromium": "node test/chromium-smoke.mjs",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write .",
@@ -17,6 +18,7 @@
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.10",
     "jsdom": "^29.1.1",
+    "playwright": "1.61.1",
     "prettier": "3.9.5",
     "vitest": "^4.1.10",
     "web-ext": "10.5.0"

--- a/test/chromium-smoke.mjs
+++ b/test/chromium-smoke.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const EXTENSION_PATH = path.join(ROOT, "src");
+const BIRTH_DATE = "1990-06-15";
+const SAVED_BIRTH = `${BIRTH_DATE}T00:00`;
+const PAPER_BACKGROUND = "#fafaf8";
+
+function assertExtensionPage(page) {
+  const url = new URL(page.url());
+  assert.equal(url.protocol, "chrome-extension:");
+  assert.equal(url.pathname, "/tab.html");
+}
+
+async function openNewTab(context, existingPage) {
+  const page = existingPage ?? (await context.newPage());
+  await page.goto("chrome://newtab/");
+  await page.waitForURL(
+    (url) =>
+      url.protocol === "chrome-extension:" && url.pathname === "/tab.html",
+  );
+  assertExtensionPage(page);
+  await page.locator("#app > *").first().waitFor({ state: "visible" });
+  return page;
+}
+
+async function assertLiveCounter(page) {
+  await page.locator("body.screen-counter").waitFor({ state: "visible" });
+  const count = page.locator("#count");
+  await count.waitFor({ state: "visible" });
+  await page.waitForFunction(() =>
+    /\d/.test(document.querySelector("#count")?.textContent ?? ""),
+  );
+  assert.match((await count.innerText()).trim(), /\d/);
+}
+
+async function runSmoke(context) {
+  const initialPage = context.pages()[0] ?? (await context.newPage());
+  const page = await openNewTab(context, initialPage);
+
+  await page.locator("body.screen-setup").waitFor({ state: "visible" });
+  const birthDate = page.locator("#birth-date");
+  await birthDate.waitFor({ state: "visible" });
+  await birthDate.fill(BIRTH_DATE);
+  await birthDate.press("Enter");
+  await assertLiveCounter(page);
+
+  await page.locator("#gear").click();
+  await page.locator("body.screen-settings").waitFor({ state: "visible" });
+  await page.locator('[data-preset="Paper"]').click();
+  await page.waitForFunction(
+    async ({ birth, background }) => {
+      const { mortality } = await chrome.storage.local.get("mortality");
+      return mortality?.birth === birth && mortality?.theme?.bg === background;
+    },
+    { birth: SAVED_BIRTH, background: PAPER_BACKGROUND },
+  );
+
+  await page.keyboard.press("Escape");
+  await assertLiveCounter(page);
+  assert.equal(
+    await page.locator("#gear").evaluate((element) => {
+      return document.activeElement === element;
+    }),
+    true,
+  );
+
+  const persistedPage = await openNewTab(context);
+  await assertLiveCounter(persistedPage);
+  await persistedPage.reload();
+  await assertLiveCounter(persistedPage);
+  await persistedPage.locator("#gear").click();
+  await persistedPage
+    .locator("body.screen-settings")
+    .waitFor({ state: "visible" });
+  assert.equal(
+    await persistedPage
+      .locator('[data-preset="Paper"]')
+      .getAttribute("aria-pressed"),
+    "true",
+  );
+}
+
+const userDataDir = await mkdtemp(
+  path.join(os.tmpdir(), "mortality-chromium-"),
+);
+const errors = [];
+let context;
+
+try {
+  context = await chromium.launchPersistentContext(userDataDir, {
+    channel: "chromium",
+    headless: true,
+    locale: "en-US",
+    reducedMotion: "reduce",
+    timezoneId: "UTC",
+    args: [
+      `--disable-extensions-except=${EXTENSION_PATH}`,
+      `--load-extension=${EXTENSION_PATH}`,
+    ],
+  });
+  await runSmoke(context);
+} catch (error) {
+  errors.push(error);
+}
+
+try {
+  await context?.close();
+} catch (error) {
+  errors.push(error);
+}
+
+try {
+  await rm(userDataDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+} catch (error) {
+  errors.push(error);
+}
+
+if (errors.length === 1) throw errors[0];
+if (errors.length > 1) {
+  throw new AggregateError(errors, "Chromium smoke test and cleanup failed");
+}
+
+console.log("Chromium extension smoke test passed");


### PR DESCRIPTION
## Summary
- add a Playwright-backed smoke test that loads `src/` as an unpacked MV3 extension and enters through `chrome://newtab/`
- cover first-run setup with a synthetic birth date, the live counter, a keyboard dismissal/focus path, and theme persistence across a fresh tab and reload
- add `npm run test:chromium`, deterministic Playwright Chromium installation in CI, and concise developer instructions

## Rationale
The existing Vitest/jsdom coverage exercises the application flow but cannot verify that Chromium accepts the shipped manifest, installs the unpacked extension, applies the new-tab override, or persists data through the real extension storage API. This focused smoke closes that gap in line with Chrome Web Store testing guidance while keeping all tooling dev-only.

## Validation
- `npm run test:chromium`
- `npm test` (474 tests)
- `npm run format:check`
- `npm run zip` (archive contains only `src/` extension files; no Playwright or test tooling)

## Platform limitations
The smoke uses Playwright's pinned bundled Chromium because branded Chrome and Edge no longer support the command-line side-loading flags required by automation. It validates the Chromium extension runtime and unpacked install path, not Web Store installation/update behavior or Firefox-specific behavior.