### PR TITLE
Add public privacy policy and align trust disclosures

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,7 @@ jobs:
       - run: |
           mkdir public
           cp -R src/. public/
+          cp site/privacy.html public/privacy.html
           cp public/tab.html public/index.html
           touch public/.nojekyll
       - uses: actions/upload-pages-artifact@v5

--- a/README.md
+++ b/README.md
@@ -40,13 +40,20 @@ every
 
 ## Privacy
 
-Mortality has no accounts, servers, or analytics. It requests a single permission —
-`storage` — to save your settings locally, and collects no data. Everything stays in
-your browser.
+Mortality stores settings locally by default and requests only the `storage` permission.
+It has no Mortality account or app backend, no analytics or ads, and its developer cannot
+access your settings.
+
+Browser-account sync is off until you enable it. One opt-in syncs your theme, counter
+mode, numeral style, reflection setting, and language; a second opt-in can also sync your
+birth date and time, birth time zone, sex at birth, and selected life-expectancy data
+source or custom years through your browser vendor's sync service. Read the
+[privacy policy](https://alphabt.github.io/mortality/privacy.html) for data controls,
+export/import details, and support.
 
 ## Install
 
-<a href="https://chrome.google.com/webstore/detail/mortality/dmcopoldcoemapdejndbdnfmbofbkmbh"><img src="./images/chrome_logo.svg" width="50px"/> Add to Chrome</a>
+<a href="https://chromewebstore.google.com/detail/mortality/dmcopoldcoemapdejndbdnfmbofbkmbh"><img src="https://developer.chrome.com/static/docs/webstore/branding/image/206x58-chrome-web-043497a3d766e.png" alt="Available in the Chrome Web Store" width="206" height="58"/></a>
 
 <a href="https://addons.mozilla.org/firefox/addon/mortality/"><img src="./images/firefox_logo.svg" width="50px"/> Add to Firefox</a>
 
@@ -121,7 +128,7 @@ list, and manual runs are documented in the
 
 ## Credits
 
-- Inspired by [Motivation Chrome extension](https://chrome.google.com/webstore/detail/motivation/ofdgfpchbidcgncgfpdlpclnpaemakoj)
+- Inspired by [Motivation Chrome extension](https://chromewebstore.google.com/detail/motivation/ofdgfpchbidcgncgfpdlpclnpaemakoj)
 - Icon: original mark — a life-elapsed gauge closing on the counter's signature accent dot
 
 ## License

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -225,7 +225,7 @@
         <span>Privacy policy</span>
       </header>
 
-      <main id="main">
+      <main id="main" tabindex="-1">
         <header class="intro">
           <h1>Privacy</h1>
           <p class="lede">

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -1,0 +1,362 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light dark" />
+    <meta
+      name="description"
+      content="How Mortality stores, syncs, exports, and removes your settings."
+    />
+    <link
+      rel="canonical"
+      href="https://alphabt.github.io/mortality/privacy.html"
+    />
+    <title>Privacy — Mortality</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --bg: #ffffff;
+        --ink: #494949;
+        --muted: #6f747a;
+        --accent: #007ea6;
+        --focus: #005f80;
+        --rule: #d7dadd;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #222222;
+          --ink: #b0b5b9;
+          --muted: #898f97;
+          --accent: #5cc2ea;
+          --focus: #5cc2ea;
+          --rule: #4a4e52;
+        }
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html {
+        background: var(--bg);
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: Avenir, "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-size: 1rem;
+        line-height: 1.65;
+      }
+
+      .skip-link {
+        position: absolute;
+        inset-block-start: 0.75rem;
+        inset-inline-start: 0.75rem;
+        z-index: 1;
+        padding: 0.45rem 0.7rem;
+        background: var(--bg);
+        color: var(--ink);
+        transform: translateY(-200%);
+      }
+
+      .skip-link:focus {
+        transform: translateY(0);
+      }
+
+      .page {
+        width: min(calc(100% - 2.5rem), 46rem);
+        margin-inline: auto;
+        padding-block: 2.5rem 4rem;
+      }
+
+      .site-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
+        padding-block-end: 1.5rem;
+        border-block-end: 1px solid var(--rule);
+      }
+
+      .brand {
+        color: var(--ink);
+        font-size: 1.05rem;
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .site-header span,
+      .updated {
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      .intro {
+        padding-block: 3rem 0.25rem;
+      }
+
+      h1,
+      h2,
+      h3 {
+        color: var(--ink);
+        line-height: 1.2;
+        text-wrap: balance;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 2.5rem;
+        font-weight: 600;
+      }
+
+      h2 {
+        margin: 0 0 0.85rem;
+        font-size: 1.35rem;
+        font-weight: 600;
+      }
+
+      h3 {
+        margin: 1.5rem 0 0.35rem;
+        font-size: 1.05rem;
+        font-weight: 600;
+      }
+
+      p,
+      ul {
+        max-width: 70ch;
+        margin-block: 0.75rem;
+        text-wrap: pretty;
+      }
+
+      .lede {
+        max-width: 58ch;
+        margin-block: 0.8rem;
+        font-size: 1.2rem;
+        line-height: 1.5;
+      }
+
+      .updated {
+        margin-block-start: 1.25rem;
+      }
+
+      section {
+        margin-block-start: 2.5rem;
+        padding-block-start: 2.5rem;
+        border-block-start: 1px solid var(--rule);
+      }
+
+      ul {
+        padding-inline-start: 1.25rem;
+      }
+
+      li + li {
+        margin-block-start: 0.45rem;
+      }
+
+      a {
+        color: var(--accent);
+        text-decoration-thickness: 0.08em;
+        text-underline-offset: 0.18em;
+      }
+
+      a:hover {
+        text-decoration-thickness: 0.13em;
+      }
+
+      a:focus-visible {
+        outline: 2px solid var(--focus);
+        outline-offset: 3px;
+        border-radius: 2px;
+      }
+
+      footer {
+        margin-block-start: 3rem;
+        padding-block-start: 1.5rem;
+        border-block-start: 1px solid var(--rule);
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      @media (max-width: 32rem) {
+        .page {
+          width: min(calc(100% - 2rem), 46rem);
+          padding-block-start: 1.5rem;
+        }
+
+        .site-header {
+          align-items: flex-start;
+          flex-direction: column;
+          gap: 0.2rem;
+        }
+
+        .intro {
+          padding-block-start: 2.25rem;
+        }
+
+        h1 {
+          font-size: 2rem;
+        }
+      }
+
+      @media print {
+        .skip-link {
+          display: none;
+        }
+
+        .page {
+          width: 100%;
+          padding: 0;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <div class="page">
+      <header class="site-header">
+        <a class="brand" href="./">Mortality</a>
+        <span>Privacy policy</span>
+      </header>
+
+      <main id="main">
+        <header class="intro">
+          <h1>Privacy</h1>
+          <p class="lede">
+            Mortality keeps your information on your device unless you choose to
+            sync it through your browser account.
+          </p>
+          <p class="updated">
+            Last updated <time datetime="2026-07-12">12 July 2026</time>
+          </p>
+        </header>
+
+        <section aria-labelledby="local">
+          <h2 id="local">Local by default</h2>
+          <p>
+            The installed extension saves your birthday and related settings in
+            your browser extension’s local storage. This includes your birth
+            date and time, birth time zone, optional sex-at-birth value,
+            life-expectancy choice, theme, counter mode, numeral style,
+            reflection setting, and language.
+          </p>
+          <p>
+            The online demo uses this browser’s local storage instead. Nothing
+            is synced unless you turn sync on in <strong>Settings</strong>.
+          </p>
+        </section>
+
+        <section aria-labelledby="optional-sync">
+          <h2 id="optional-sync">Optional browser sync</h2>
+          <p>
+            Sync has two separate opt-ins. The second is available only after
+            you enable the first.
+          </p>
+
+          <h3>Preferences</h3>
+          <p>
+            <strong>Sync preferences across devices</strong> syncs only your
+            theme and custom colors, counter mode, numeral style, reflection
+            setting, and language.
+          </p>
+
+          <h3>Personal profile</h3>
+          <p>
+            <strong>Also sync birthday and life-expectancy details</strong>
+            additionally syncs your birth date and time, birth time zone,
+            optional sex-at-birth value, and selected life-expectancy data
+            source or custom number of years.
+          </p>
+
+          <p>
+            When enabled, Mortality writes these fields to your browser vendor’s
+            account and sync-storage service. Google, Mozilla, or Microsoft
+            provides that service, depending on your browser. Mortality also
+            stores limited technical sync metadata: enabled scopes, a random
+            writer ID, schema version, and update time. These records let
+            devices reconcile changes; they are not sent to Mortality.
+          </p>
+        </section>
+
+        <section aria-labelledby="access">
+          <h2 id="access">No Mortality account or backend</h2>
+          <p>
+            Mortality has no account system, app backend, analytics,
+            advertising, or developer access to your local or synced settings.
+            The extension does not send those settings to Mortality’s developer.
+          </p>
+          <p>
+            This policy page and the online demo are hosted by GitHub Pages.
+            Mortality adds no analytics, advertising, or tracking scripts to
+            them.
+          </p>
+        </section>
+
+        <section aria-labelledby="control">
+          <h2 id="control">Disable sync and remove synced data</h2>
+          <p>Open <strong>Settings → Device sync</strong>:</p>
+          <ul>
+            <li>
+              Turn off
+              <strong>Also sync birthday and life-expectancy details</strong>
+              to remove the personal-profile payload from browser sync storage
+              while keeping preference sync on.
+            </li>
+            <li>
+              Turn off <strong>Sync preferences across devices</strong> to
+              disable both scopes and remove both preference and personal
+              payloads from browser sync storage.
+            </li>
+          </ul>
+          <p>
+            Disabling sync does not delete the settings saved on your current
+            device. A small configuration record indicating that sync is off may
+            remain so other devices can respect that choice. For browser-managed
+            records beyond these payloads, use your browser vendor’s sync-data
+            controls.
+          </p>
+        </section>
+
+        <section aria-labelledby="portability">
+          <h2 id="portability">Export and import</h2>
+          <p>
+            <strong>Settings → Data → Export</strong> downloads
+            <code>mortality-settings.json</code> with your current Mortality
+            settings. Import reads a settings file on your device and applies
+            its recognized values to the local settings. The file is not
+            uploaded to Mortality.
+          </p>
+          <p>
+            If browser sync is enabled when you import, fields covered by your
+            enabled sync scopes are then mirrored through the browser vendor’s
+            sync service.
+          </p>
+        </section>
+
+        <section aria-labelledby="support">
+          <h2 id="support">Contact and support</h2>
+          <p>
+            For privacy questions or support, open an issue in the
+            <a href="https://github.com/alphabt/mortality/issues"
+              >Mortality support tracker</a
+            >. Issues are public, so do not include your birthday or other
+            personal information.
+          </p>
+          <p>
+            Mortality’s
+            <a href="https://github.com/alphabt/mortality">source code</a> is
+            public.
+          </p>
+        </section>
+      </main>
+
+      <footer>Mortality · A quiet measure of time.</footer>
+    </div>
+  </body>
+</html>

--- a/test/privacy.test.js
+++ b/test/privacy.test.js
@@ -1,0 +1,69 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (...parts) => readFileSync(join(ROOT, ...parts), "utf8");
+
+describe("privacy and trust surfaces", () => {
+  it("deploys a stable site-only policy page", () => {
+    const policyPath = join(ROOT, "site", "privacy.html");
+    const workflow = read(".github", "workflows", "pages.yml");
+    const pack = read("scripts", "pack.sh");
+
+    expect(existsSync(policyPath)).toBe(true);
+    expect(existsSync(join(ROOT, "src", "privacy.html"))).toBe(false);
+    expect(workflow).toContain("cp site/privacy.html public/privacy.html");
+    expect(pack).toContain("(cd src && zip");
+    expect(pack).not.toContain("site/");
+  });
+
+  it("documents the implemented storage, sync, and data controls", () => {
+    const policy = read("site", "privacy.html");
+    const normalized = policy.replace(/\s+/g, " ").toLowerCase();
+
+    expect(normalized).toContain(
+      '<link rel="canonical" href="https://alphabt.github.io/mortality/privacy.html"',
+    );
+    expect(policy).toContain('<main id="main">');
+    expect(policy).toContain("<h1>Privacy</h1>");
+    expect(policy).toContain(":focus-visible");
+    expect(policy).not.toContain("<script");
+
+    for (const disclosure of [
+      "local by default",
+      "theme and custom colors",
+      "counter mode",
+      "numeral style",
+      "reflection setting",
+      "language",
+      "birth date and time",
+      "birth time zone",
+      "sex-at-birth value",
+      "life-expectancy data source or custom number of years",
+      "browser vendor’s account and sync-storage service",
+      "no mortality account or backend",
+      "remove both preference and personal payloads",
+      "mortality-settings.json",
+      "the file is not uploaded to mortality",
+      "contact and support",
+    ]) {
+      expect(normalized).toContain(disclosure);
+    }
+  });
+
+  it("uses Google's official badge and canonical Chrome listing", () => {
+    const readme = read("README.md");
+
+    expect(readme).toContain(
+      "https://chromewebstore.google.com/detail/mortality/dmcopoldcoemapdejndbdnfmbofbkmbh",
+    );
+    expect(readme).toContain(
+      "https://developer.chrome.com/static/docs/webstore/branding/image/206x58-chrome-web-043497a3d766e.png",
+    );
+    expect(readme).toContain('width="206" height="58"');
+    expect(readme).not.toContain("chrome_logo.svg");
+    expect(readme).not.toContain("chrome.google.com/webstore");
+  });
+});

--- a/test/privacy.test.js
+++ b/test/privacy.test.js
@@ -11,12 +11,15 @@ describe("privacy and trust surfaces", () => {
     const policyPath = join(ROOT, "site", "privacy.html");
     const workflow = read(".github", "workflows", "pages.yml");
     const pack = read("scripts", "pack.sh");
+    const zipInvocation = pack
+      .split("\n")
+      .find((line) => line.includes("zip -rqX"));
 
     expect(existsSync(policyPath)).toBe(true);
     expect(existsSync(join(ROOT, "src", "privacy.html"))).toBe(false);
     expect(workflow).toContain("cp site/privacy.html public/privacy.html");
-    expect(pack).toContain("(cd src && zip");
-    expect(pack).not.toContain("site/");
+    expect(zipInvocation).toContain("(cd src && zip");
+    expect(zipInvocation).not.toContain("site/");
   });
 
   it("documents the implemented storage, sync, and data controls", () => {
@@ -26,7 +29,7 @@ describe("privacy and trust surfaces", () => {
     expect(normalized).toContain(
       '<link rel="canonical" href="https://alphabt.github.io/mortality/privacy.html"',
     );
-    expect(policy).toContain('<main id="main">');
+    expect(policy).toContain('<main id="main" tabindex="-1">');
     expect(policy).toContain("<h1>Privacy</h1>");
     expect(policy).toContain(":focus-visible");
     expect(policy).not.toContain("<script");


### PR DESCRIPTION
## Summary

- add a calm, accessible, light/dark privacy-policy page for `https://alphabt.github.io/mortality/privacy.html`
- document local-by-default storage, both explicit browser-sync scopes and fields, browser-vendor storage, disable/removal behavior, export/import, hosting, and support
- keep the page outside `src/` and copy only `site/privacy.html` into the GitHub Pages artifact, so site-only content is not packaged with the extension
- correct README privacy wording and replace the custom Chrome logo/legacy URL with Google’s official unmodified 206×58 Chrome Web Store badge and canonical listing URL
- add regression coverage for the stable route, required disclosures, deployment/package boundary, and badge/link

## Validation

- `npm test` — 14 files, 477 tests passed
- `npm run format:check`
- `npm run zip`
- confirmed `privacy.html` and `site/` are absent from `artifacts/mortality-v1.6.0.zip`

## Post-merge dashboard action

**Required manual action:** set the Chrome Web Store privacy-policy URL to `https://alphabt.github.io/mortality/privacy.html`, then re-check the Chrome data-use declarations against the two opt-in sync scopes and Mortality’s lack of an account, backend, analytics, ads, or developer access to settings.