### PR TITLE
Add canonical store listing metadata

### DIFF
--- a/.github/workflows/publish-firefox-metadata.yml
+++ b/.github/workflows/publish-firefox-metadata.yml
@@ -1,0 +1,72 @@
+name: "publish-firefox-metadata"
+
+# Listing metadata stays separate from release/package publishing so an AMO
+# update cannot silently drift ahead of the manual Chrome and Edge listings.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Print the payload, or publish it to the Firefox listing"
+        type: choice
+        options:
+          - dry-run
+          - apply
+        default: dry-run
+        required: true
+      confirmation:
+        description: "For apply mode only, type PUBLISH FIREFOX METADATA"
+        type: string
+        default: ""
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-firefox-metadata
+  cancel-in-progress: false
+
+jobs:
+  dry-run:
+    name: "Show AMO metadata payload"
+    if: inputs.mode == 'dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - run: npm run --silent store:publish:firefox-metadata
+
+  apply:
+    name: "Publish AMO metadata"
+    if: inputs.mode == 'apply'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require default branch and explicit confirmation
+        env:
+          SELECTED_REF: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          if [ "$SELECTED_REF" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::Apply mode must run from the repository default branch ($DEFAULT_BRANCH), not $SELECTED_REF."
+            exit 1
+          fi
+          if [ "$CONFIRMATION" != "PUBLISH FIREFOX METADATA" ]; then
+            echo "::error::Type PUBLISH FIREFOX METADATA to confirm apply mode."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Publish supported listing fields
+        env:
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+          FIREFOX_ADDON_ID: ${{ secrets.FIREFOX_ADDON_ID }}
+        run: npm run store:publish:firefox-metadata -- --apply

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "store:validate": "node scripts/validate-store-metadata.mjs",
-    "store:show": "node scripts/validate-store-metadata.mjs --locale"
+    "store:show": "node scripts/validate-store-metadata.mjs --locale",
+    "store:publish:firefox-metadata": "node scripts/publish-firefox-metadata.mjs"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "store:validate": "node scripts/validate-store-metadata.mjs",
+    "store:show": "node scripts/validate-store-metadata.mjs --locale"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.10",

--- a/scripts/publish-firefox-metadata.mjs
+++ b/scripts/publish-firefox-metadata.mjs
@@ -1,0 +1,228 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  loadStoreMetadata,
+  renderFullDescription,
+  validateStoreMetadata,
+} from "./validate-store-metadata.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export const AMO_API_BASE = "https://addons.mozilla.org/api/v5/addons/addon";
+
+function encodeJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function redact(value, sensitiveValues) {
+  let redacted = String(value);
+  for (const sensitiveValue of sensitiveValues) {
+    if (sensitiveValue) {
+      redacted = redacted.replaceAll(sensitiveValue, "[REDACTED]");
+    }
+  }
+  return redacted;
+}
+
+export function createAmoJwt({
+  issuer,
+  secret,
+  issuedAt = Math.floor(Date.now() / 1000),
+  jwtId = randomUUID(),
+}) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const claims = {
+    iss: issuer,
+    jti: jwtId,
+    iat: issuedAt,
+    exp: issuedAt + 60,
+  };
+  const signingInput = `${encodeJson(header)}.${encodeJson(claims)}`;
+  const signature = createHmac("sha256", secret)
+    .update(signingInput)
+    .digest("base64url");
+
+  return `${signingInput}.${signature}`;
+}
+
+export function buildAmoMetadataPayload(metadata, summaries) {
+  const name = {};
+  const summary = {};
+  const description = {};
+  const homepage = {};
+
+  for (const [repositoryLocale, localeMetadata] of Object.entries(
+    metadata.locales,
+  )) {
+    const amoLocale = localeMetadata.storeLocales.firefox;
+    const localizedSummary = summaries[repositoryLocale];
+    if (!localizedSummary) {
+      throw new Error(
+        `Validated package summary is missing for locale "${repositoryLocale}"`,
+      );
+    }
+
+    name[amoLocale] = metadata.productName;
+    summary[amoLocale] = localizedSummary;
+    description[amoLocale] = renderFullDescription(localeMetadata);
+    homepage[amoLocale] = metadata.urls.website;
+  }
+
+  return {
+    name,
+    summary,
+    description,
+    homepage,
+    tags: [...metadata.firefox.tags],
+  };
+}
+
+export function validateAndBuildAmoPayload(metadata, { root = ROOT } = {}) {
+  const validation = validateStoreMetadata(metadata, { root });
+  if (validation.errors.length > 0) {
+    throw new Error(
+      `Store metadata validation failed:\n${validation.errors
+        .map((error) => `- ${error}`)
+        .join("\n")}`,
+    );
+  }
+
+  return buildAmoMetadataPayload(metadata, validation.summaries);
+}
+
+export function loadAmoMetadataPayload(root = ROOT) {
+  let metadata;
+  try {
+    metadata = loadStoreMetadata(root);
+  } catch (error) {
+    throw new Error(
+      `Unable to load canonical store metadata: ${error.message}`,
+    );
+  }
+  return validateAndBuildAmoPayload(metadata, { root });
+}
+
+export function buildAmoEndpoint(addonId, apiBase = AMO_API_BASE) {
+  return `${apiBase.replace(/\/+$/u, "")}/${encodeURIComponent(addonId)}/`;
+}
+
+export function requireAmoCredentials(environment) {
+  const names = [
+    "FIREFOX_JWT_ISSUER",
+    "FIREFOX_JWT_SECRET",
+    "FIREFOX_ADDON_ID",
+  ];
+  const missing = names.filter(
+    (name) =>
+      typeof environment[name] !== "string" || environment[name].trim() === "",
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `--apply requires the following environment variables: ${missing.join(", ")}`,
+    );
+  }
+
+  return {
+    issuer: environment.FIREFOX_JWT_ISSUER.trim(),
+    secret: environment.FIREFOX_JWT_SECRET.trim(),
+    addonId: environment.FIREFOX_ADDON_ID.trim(),
+  };
+}
+
+export async function publishAmoMetadata({
+  payload,
+  issuer,
+  secret,
+  addonId,
+  fetchImpl = globalThis.fetch,
+  apiBase = AMO_API_BASE,
+  issuedAt,
+  jwtId,
+}) {
+  const token = createAmoJwt({ issuer, secret, issuedAt, jwtId });
+  let response;
+
+  try {
+    response = await fetchImpl(buildAmoEndpoint(addonId, apiBase), {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        Authorization: `JWT ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `AMO metadata request failed: ${redact(message, [
+        issuer,
+        secret,
+        token,
+      ])}`,
+    );
+  }
+
+  if (!response.ok) {
+    let responseBody;
+    try {
+      responseBody = await response.text();
+    } catch {
+      responseBody = "response body could not be read";
+    }
+    const detail = redact(responseBody, [issuer, secret, token]).slice(
+      0,
+      2_000,
+    );
+    throw new Error(
+      `AMO metadata update failed with HTTP ${response.status}${
+        detail ? `: ${detail}` : ""
+      }`,
+    );
+  }
+
+  return response.status;
+}
+
+function printUsage() {
+  console.log(
+    "Usage: node scripts/publish-firefox-metadata.mjs [--apply]\n\n" +
+      "Without --apply, prints the exact validated AMO PATCH payload and does not require credentials.",
+  );
+}
+
+export async function runCli({
+  args = process.argv.slice(2),
+  environment = process.env,
+} = {}) {
+  if (args.length === 1 && args[0] === "--help") {
+    printUsage();
+    return;
+  }
+  if (args.length > 1 || (args.length === 1 && args[0] !== "--apply")) {
+    throw new Error(
+      "Usage: node scripts/publish-firefox-metadata.mjs [--apply]",
+    );
+  }
+
+  const payload = loadAmoMetadataPayload();
+  if (args.length === 0) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+
+  const credentials = requireAmoCredentials(environment);
+  const status = await publishAmoMetadata({ payload, ...credentials });
+  console.log(`Firefox listing metadata published to AMO (HTTP ${status}).`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/validate-store-metadata.mjs
+++ b/scripts/validate-store-metadata.mjs
@@ -1,0 +1,560 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const METADATA_PATH = join(ROOT, "store-listing", "metadata.json");
+
+export const PRIORITY_LOCALES = [
+  "en",
+  "de",
+  "es",
+  "fr",
+  "ja",
+  "pt_BR",
+  "zh_CN",
+  "zh_TW",
+  "ko",
+];
+
+const STORE_LOCALES = {
+  en: { chrome: "en", edge: "en-US", firefox: "en-US" },
+  de: { chrome: "de", edge: "de-DE", firefox: "de" },
+  es: { chrome: "es", edge: "es-ES", firefox: "es" },
+  fr: { chrome: "fr", edge: "fr-FR", firefox: "fr" },
+  ja: { chrome: "ja", edge: "ja-JP", firefox: "ja" },
+  pt_BR: { chrome: "pt_BR", edge: "pt-BR", firefox: "pt-BR" },
+  zh_CN: { chrome: "zh_CN", edge: "zh-CN", firefox: "zh-CN" },
+  zh_TW: { chrome: "zh_TW", edge: "zh-TW", firefox: "zh-TW" },
+  ko: { chrome: "ko", edge: "ko-KR", firefox: "ko" },
+};
+const FIREFOX_ALLOWED_TAGS = new Set([
+  "ad blocker",
+  "anti malware",
+  "anti tracker",
+  "antivirus",
+  "chat",
+  "container",
+  "content blocker",
+  "coupon",
+  "dailymotion",
+  "dark mode",
+  "dndbeyond",
+  "download",
+  "facebook",
+  "google",
+  "image search",
+  "mp3",
+  "music",
+  "password manager",
+  "pinterest",
+  "pixiv",
+  "privacy",
+  "reddit",
+  "roblox",
+  "scholar",
+  "search",
+  "security",
+  "shopping",
+  "social media",
+  "streaming",
+  "torrent",
+  "translate",
+  "twitch",
+  "twitter",
+  "user scripts",
+  "video converter",
+  "video downloader",
+  "vpn",
+  "wayback machine",
+  "whatsapp",
+  "word counter",
+  "youtube",
+  "zoom",
+]);
+const SUMMARY_MAX_LENGTH = 132;
+const DESCRIPTION_MIN_LENGTH = 250;
+const DESCRIPTION_MAX_LENGTH = 10_000;
+const EDGE_MAX_SEARCH_TERMS = 7;
+const EDGE_MAX_SEARCH_WORDS = 21;
+const EDGE_MAX_TERM_LENGTH = 30;
+const FIREFOX_TAG_MAX_LENGTH = 30;
+const EXPECTED_URLS = {
+  website: "https://alphabt.github.io/mortality/",
+  support: "https://github.com/alphabt/mortality/issues",
+  privacy: "https://alphabt.github.io/mortality/privacy.html",
+};
+const FORBIDDEN_COPY = /death[\s-]+clock/iu;
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function codePointLength(value) {
+  return [...value].length;
+}
+
+function readJson(path, errors, label) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    errors.push(`${label} is not readable JSON: ${error.message}`);
+    return null;
+  }
+}
+
+function expectKeys(value, expected, label, errors) {
+  if (!isRecord(value)) {
+    errors.push(`${label} must be an object`);
+    return false;
+  }
+
+  let valid = true;
+  const expectedSet = new Set(expected);
+  for (const key of expected) {
+    if (!(key in value)) {
+      errors.push(`${label} is missing "${key}"`);
+      valid = false;
+    }
+  }
+  for (const key of Object.keys(value)) {
+    if (!expectedSet.has(key)) {
+      errors.push(`${label} has unknown field "${key}"`);
+      valid = false;
+    }
+  }
+  return valid;
+}
+
+function collectStrings(value, path = "metadata", strings = []) {
+  if (typeof value === "string") {
+    strings.push([path, value]);
+  } else if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectStrings(item, `${path}[${index}]`, strings),
+    );
+  } else if (isRecord(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      collectStrings(item, `${path}.${key}`, strings);
+    }
+  }
+  return strings;
+}
+
+export function renderFullDescription(localeMetadata) {
+  return localeMetadata.fullDescription.join("\n\n");
+}
+
+export function loadStoreMetadata(root = ROOT) {
+  return JSON.parse(
+    readFileSync(join(root, "store-listing", "metadata.json"), "utf8"),
+  );
+}
+
+export function validateStoreMetadata(metadata, { root = ROOT } = {}) {
+  const errors = [];
+  const summaries = {};
+  let catalogCount = 0;
+
+  if (
+    !expectKeys(
+      metadata,
+      [
+        "schemaVersion",
+        "productName",
+        "summary",
+        "urls",
+        "chrome",
+        "firefox",
+        "locales",
+      ],
+      "metadata",
+      errors,
+    )
+  ) {
+    return { errors, summaries, catalogCount };
+  }
+
+  if (metadata.schemaVersion !== 1) {
+    errors.push("metadata.schemaVersion must be 1");
+  }
+  if (metadata.productName !== "Mortality") {
+    errors.push('metadata.productName must be "Mortality"');
+  }
+
+  const summaryIsValid = expectKeys(
+    metadata.summary,
+    ["catalogDirectory", "nameMessageKey", "descriptionMessageKey"],
+    "metadata.summary",
+    errors,
+  );
+  if (summaryIsValid) {
+    if (metadata.summary.catalogDirectory !== "src/_locales") {
+      errors.push('metadata.summary.catalogDirectory must be "src/_locales"');
+    }
+    if (metadata.summary.nameMessageKey !== "extName") {
+      errors.push('metadata.summary.nameMessageKey must be "extName"');
+    }
+    if (metadata.summary.descriptionMessageKey !== "extDescription") {
+      errors.push(
+        'metadata.summary.descriptionMessageKey must be "extDescription"',
+      );
+    }
+  }
+
+  if (
+    expectKeys(
+      metadata.urls,
+      ["website", "support", "privacy"],
+      "metadata.urls",
+      errors,
+    )
+  ) {
+    for (const [name, expected] of Object.entries(EXPECTED_URLS)) {
+      const value = metadata.urls[name];
+      if (value !== expected) {
+        errors.push(`metadata.urls.${name} must be ${expected}`);
+      }
+      try {
+        const url = new URL(value);
+        if (url.protocol !== "https:") {
+          errors.push(`metadata.urls.${name} must use HTTPS`);
+        }
+        if (url.search || url.hash) {
+          errors.push(`metadata.urls.${name} must not contain a query or hash`);
+        }
+      } catch {
+        errors.push(`metadata.urls.${name} must be a valid URL`);
+      }
+    }
+  }
+
+  if (expectKeys(metadata.chrome, ["category"], "metadata.chrome", errors)) {
+    if (metadata.chrome.category !== "Well-being") {
+      errors.push('metadata.chrome.category must be "Well-being"');
+    }
+  }
+
+  if (expectKeys(metadata.firefox, ["tags"], "metadata.firefox", errors)) {
+    if (
+      !Array.isArray(metadata.firefox.tags) ||
+      metadata.firefox.tags.length === 0
+    ) {
+      errors.push("metadata.firefox.tags must be a non-empty array");
+    } else {
+      const seen = new Set();
+      for (const [index, tag] of metadata.firefox.tags.entries()) {
+        const label = `metadata.firefox.tags[${index}]`;
+        if (typeof tag !== "string" || tag.trim() !== tag || tag === "") {
+          errors.push(`${label} must be a trimmed, non-empty string`);
+          continue;
+        }
+        if (codePointLength(tag) > FIREFOX_TAG_MAX_LENGTH) {
+          errors.push(`${label} exceeds the 30-character repository guard`);
+        }
+        const normalized = tag.toLocaleLowerCase("en");
+        if (seen.has(normalized)) errors.push(`${label} is duplicated`);
+        if (!FIREFOX_ALLOWED_TAGS.has(normalized)) {
+          errors.push(`${label} is not in Firefox's allowed tag vocabulary`);
+        }
+        seen.add(normalized);
+      }
+    }
+  }
+
+  if (!isRecord(metadata.locales)) {
+    errors.push("metadata.locales must be an object");
+  } else {
+    for (const locale of PRIORITY_LOCALES) {
+      if (!(locale in metadata.locales)) {
+        errors.push(`metadata.locales is missing priority locale "${locale}"`);
+      }
+    }
+
+    for (const [locale, localeMetadata] of Object.entries(metadata.locales)) {
+      const label = `metadata.locales.${locale}`;
+      if (
+        !expectKeys(
+          localeMetadata,
+          ["storeLocales", "fullDescription", "edgeSearchTerms"],
+          label,
+          errors,
+        )
+      ) {
+        continue;
+      }
+
+      if (
+        expectKeys(
+          localeMetadata.storeLocales,
+          ["chrome", "edge", "firefox"],
+          `${label}.storeLocales`,
+          errors,
+        )
+      ) {
+        for (const [store, storeLocale] of Object.entries(
+          localeMetadata.storeLocales,
+        )) {
+          if (
+            typeof storeLocale !== "string" ||
+            storeLocale.trim() !== storeLocale ||
+            storeLocale === ""
+          ) {
+            errors.push(
+              `${label}.storeLocales.${store} must be a trimmed, non-empty string`,
+            );
+          }
+        }
+        const expectedStoreLocales = STORE_LOCALES[locale];
+        if (!expectedStoreLocales) {
+          errors.push(`${label} has no supported store-locale mapping`);
+        } else {
+          for (const [store, expectedLocale] of Object.entries(
+            expectedStoreLocales,
+          )) {
+            if (localeMetadata.storeLocales[store] !== expectedLocale) {
+              errors.push(
+                `${label}.storeLocales.${store} must be "${expectedLocale}"`,
+              );
+            }
+          }
+        }
+      }
+
+      if (
+        !Array.isArray(localeMetadata.fullDescription) ||
+        localeMetadata.fullDescription.length === 0 ||
+        localeMetadata.fullDescription.some(
+          (paragraph) =>
+            typeof paragraph !== "string" || paragraph.trim() === "",
+        )
+      ) {
+        errors.push(
+          `${label}.fullDescription must be an array of non-empty paragraphs`,
+        );
+      } else {
+        const description = renderFullDescription(localeMetadata);
+        const length = codePointLength(description);
+        if (length < DESCRIPTION_MIN_LENGTH) {
+          errors.push(
+            `${label}.fullDescription is shorter than Edge's 250-character minimum`,
+          );
+        }
+        if (length > DESCRIPTION_MAX_LENGTH) {
+          errors.push(
+            `${label}.fullDescription exceeds Edge's 10,000-character maximum`,
+          );
+        }
+        if (!description.includes(metadata.productName)) {
+          errors.push(
+            `${label}.fullDescription must keep "Mortality" untranslated`,
+          );
+        }
+      }
+
+      if (!Array.isArray(localeMetadata.edgeSearchTerms)) {
+        errors.push(`${label}.edgeSearchTerms must be an array`);
+      } else {
+        if (localeMetadata.edgeSearchTerms.length === 0) {
+          errors.push(`${label}.edgeSearchTerms must not be empty`);
+        }
+        if (localeMetadata.edgeSearchTerms.length > EDGE_MAX_SEARCH_TERMS) {
+          errors.push(`${label}.edgeSearchTerms exceeds Edge's 7-term maximum`);
+        }
+
+        let words = 0;
+        const seen = new Set();
+        for (const [index, term] of localeMetadata.edgeSearchTerms.entries()) {
+          const termLabel = `${label}.edgeSearchTerms[${index}]`;
+          if (typeof term !== "string" || term.trim() !== term || term === "") {
+            errors.push(`${termLabel} must be a trimmed, non-empty string`);
+            continue;
+          }
+          if (codePointLength(term) > EDGE_MAX_TERM_LENGTH) {
+            errors.push(`${termLabel} exceeds Edge's 30-character maximum`);
+          }
+          words += term.split(/\s+/u).length;
+          const normalized = term.normalize("NFKC").toLocaleLowerCase();
+          if (seen.has(normalized)) errors.push(`${termLabel} is duplicated`);
+          seen.add(normalized);
+        }
+        if (words > EDGE_MAX_SEARCH_WORDS) {
+          errors.push(
+            `${label}.edgeSearchTerms exceeds Edge's 21-word maximum`,
+          );
+        }
+      }
+    }
+  }
+
+  if (summaryIsValid) {
+    const manifest = readJson(
+      join(root, "src", "manifest.json"),
+      errors,
+      "src/manifest.json",
+    );
+    if (manifest) {
+      const expectedName = `__MSG_${metadata.summary.nameMessageKey}__`;
+      const expectedDescription = `__MSG_${metadata.summary.descriptionMessageKey}__`;
+      if (manifest.name !== expectedName) {
+        errors.push(`src/manifest.json name must reference ${expectedName}`);
+      }
+      if (manifest.description !== expectedDescription) {
+        errors.push(
+          `src/manifest.json description must reference ${expectedDescription}`,
+        );
+      }
+      if (manifest.default_locale !== "en") {
+        errors.push('src/manifest.json default_locale must be "en"');
+      }
+    }
+
+    const catalogDirectory = join(root, metadata.summary.catalogDirectory);
+    let catalogLocales = [];
+    try {
+      catalogLocales = readdirSync(catalogDirectory, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name)
+        .sort();
+    } catch (error) {
+      errors.push(
+        `${metadata.summary.catalogDirectory} is not readable: ${error.message}`,
+      );
+    }
+    catalogCount = catalogLocales.length;
+
+    for (const locale of catalogLocales) {
+      const catalog = readJson(
+        join(catalogDirectory, locale, "messages.json"),
+        errors,
+        `${metadata.summary.catalogDirectory}/${locale}/messages.json`,
+      );
+      if (!catalog) continue;
+
+      const name = catalog[metadata.summary.nameMessageKey]?.message;
+      const summary = catalog[metadata.summary.descriptionMessageKey]?.message;
+      if (name !== metadata.productName) {
+        errors.push(
+          `${locale}.${metadata.summary.nameMessageKey} must keep "Mortality" untranslated`,
+        );
+      }
+      if (typeof summary !== "string" || summary.trim() === "") {
+        errors.push(
+          `${locale}.${metadata.summary.descriptionMessageKey} must be a non-empty string`,
+        );
+      } else {
+        summaries[locale] = summary;
+        if (codePointLength(summary) > SUMMARY_MAX_LENGTH) {
+          errors.push(
+            `${locale}.${metadata.summary.descriptionMessageKey} exceeds Chrome's 132-character summary limit`,
+          );
+        }
+      }
+    }
+
+    if (isRecord(metadata.locales)) {
+      for (const locale of Object.keys(metadata.locales)) {
+        if (!catalogLocales.includes(locale)) {
+          errors.push(
+            `metadata.locales.${locale} has no matching package catalog`,
+          );
+        }
+      }
+    }
+  }
+
+  for (const [path, value] of [
+    ...collectStrings(metadata),
+    ...Object.entries(summaries).map(([locale, summary]) => [
+      `package summary ${locale}`,
+      summary,
+    ]),
+  ]) {
+    if (FORBIDDEN_COPY.test(value)) {
+      errors.push(`${path} contains the forbidden phrase "death clock"`);
+    }
+  }
+
+  return { errors, summaries, catalogCount };
+}
+
+function printLocale(metadata, summaries, locale) {
+  const localeMetadata = metadata.locales[locale];
+  if (!localeMetadata) {
+    const available = Object.keys(metadata.locales).join(", ");
+    throw new Error(`Unknown locale "${locale}". Choose one of: ${available}`);
+  }
+
+  console.log(`LOCALE\n${locale}`);
+  console.log(`\nSTORE LOCALES`);
+  for (const [store, storeLocale] of Object.entries(
+    localeMetadata.storeLocales,
+  )) {
+    console.log(`${store}: ${storeLocale}`);
+  }
+  console.log(`\nNAME\n${metadata.productName}`);
+  console.log(`\nPACKAGE SUMMARY\n${summaries[locale]}`);
+  console.log(`\nFULL DESCRIPTION\n${renderFullDescription(localeMetadata)}`);
+  console.log(
+    `\nEDGE SEARCH TERMS\n${localeMetadata.edgeSearchTerms
+      .map((term) => `- ${term}`)
+      .join("\n")}`,
+  );
+  console.log(
+    `\nSHARED URLS\nwebsite: ${metadata.urls.website}\nsupport: ${metadata.urls.support}\nprivacy: ${metadata.urls.privacy}`,
+  );
+  console.log(
+    `\nFIREFOX TAGS (GLOBAL)\n${metadata.firefox.tags
+      .map((tag) => `- ${tag}`)
+      .join("\n")}`,
+  );
+}
+
+function runCli() {
+  const metadata = readJson(METADATA_PATH, [], "store-listing/metadata.json");
+  if (!metadata) {
+    console.error("Unable to read store-listing/metadata.json");
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = validateStoreMetadata(metadata);
+  if (result.errors.length > 0) {
+    console.error(
+      `Store metadata validation failed:\n${result.errors
+        .map((error) => `- ${error}`)
+        .join("\n")}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const args = process.argv.slice(2);
+  if (args.length === 0) {
+    console.log(
+      `Store metadata valid: ${Object.keys(metadata.locales).length} full descriptions, ${result.catalogCount} package summaries.`,
+    );
+    return;
+  }
+  if (args.length === 2 && args[0] === "--locale") {
+    try {
+      printLocale(metadata, result.summaries, args[1]);
+    } catch (error) {
+      console.error(error.message);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  console.error(
+    "Usage: node scripts/validate-store-metadata.mjs [--locale <locale>]",
+  );
+  process.exitCode = 1;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  runCli();
+}

--- a/scripts/validate-store-metadata.mjs
+++ b/scripts/validate-store-metadata.mjs
@@ -326,11 +326,13 @@ export function validateStoreMetadata(metadata, { root = ROOT } = {}) {
         localeMetadata.fullDescription.length === 0 ||
         localeMetadata.fullDescription.some(
           (paragraph) =>
-            typeof paragraph !== "string" || paragraph.trim() === "",
+            typeof paragraph !== "string" ||
+            paragraph === "" ||
+            paragraph.trim() !== paragraph,
         )
       ) {
         errors.push(
-          `${label}.fullDescription must be an array of non-empty paragraphs`,
+          `${label}.fullDescription must be an array of trimmed, non-empty paragraphs`,
         );
       } else {
         const description = renderFullDescription(localeMetadata);
@@ -374,7 +376,7 @@ export function validateStoreMetadata(metadata, { root = ROOT } = {}) {
             errors.push(`${termLabel} exceeds Edge's 30-character maximum`);
           }
           words += term.split(/\s+/u).length;
-          const normalized = term.normalize("NFKC").toLocaleLowerCase();
+          const normalized = term.normalize("NFKC").toLowerCase();
           if (seen.has(normalized)) errors.push(`${termLabel} is duplicated`);
           seen.add(normalized);
         }

--- a/scripts/validate-store-metadata.mjs
+++ b/scripts/validate-store-metadata.mjs
@@ -512,10 +512,17 @@ function printLocale(metadata, summaries, locale) {
   );
 }
 
-function runCli() {
-  const metadata = readJson(METADATA_PATH, [], "store-listing/metadata.json");
+export function runCli(metadataPath = METADATA_PATH) {
+  const readErrors = [];
+  const metadata = readJson(
+    metadataPath,
+    readErrors,
+    "store-listing/metadata.json",
+  );
   if (!metadata) {
-    console.error("Unable to read store-listing/metadata.json");
+    console.error(
+      readErrors.join("\n") || "Unable to read store-listing/metadata.json",
+    );
     process.exitCode = 1;
     return;
   }

--- a/store-listing/README.md
+++ b/store-listing/README.md
@@ -1,0 +1,153 @@
+# Store listing metadata
+
+[`metadata.json`](metadata.json) is the source of truth for content managed in
+the Chrome Web Store, Microsoft Edge Add-ons, and Firefox Add-ons dashboards.
+It owns:
+
+- the shared website, support, and privacy URLs;
+- the Chrome category;
+- detailed descriptions for the nine priority locales;
+- localized Edge search terms; and
+- Firefox's global tags.
+
+The extension name and package summary are deliberately not copied into the
+metadata file. They resolve from `extName` and `extDescription` in
+`src/_locales/*/messages.json`, as referenced by `src/manifest.json`. This keeps
+all 55 package summaries in one place.
+
+Run the validator before editing a dashboard:
+
+```sh
+npm run store:validate
+npm run store:show -- en
+npm run store:show -- de
+```
+
+`store:show` prints the package summary, detailed description, Edge search
+terms, shared URLs, platform locale codes, and global Firefox tags as one
+dashboard-ready block. Supported detailed-description locales are `en`, `de`,
+`es`, `fr`, `ja`, `pt_BR`, `zh_CN`, `zh_TW`, and `ko`.
+
+## Shared canonical content
+
+Use the following fields on every store where the dashboard exposes them:
+
+| Field   | Canonical value                                      |
+| ------- | ---------------------------------------------------- |
+| Name    | `Mortality`                                          |
+| Summary | Resolved from each locale's `extDescription` message |
+| Website | `https://alphabt.github.io/mortality/`               |
+| Support | `https://github.com/alphabt/mortality/issues`        |
+| Privacy | `https://alphabt.github.io/mortality/privacy.html`   |
+
+Detailed descriptions are also shared across stores. Platform-only discovery
+fields stay separate:
+
+| Store   | Platform-only field                                            |
+| ------- | -------------------------------------------------------------- |
+| Chrome  | Category: `Well-being`; Chrome has no dedicated keyword field. |
+| Edge    | Localized search terms: at most 7 terms and 21 words in total. |
+| Firefox | Global, unlocalized tags: `dark mode` and `privacy`.           |
+
+Firefox only accepts tags from its current global tag vocabulary. The two tags
+above were available in the official
+[`/api/v5/addons/tags/`](https://addons.mozilla.org/api/v5/addons/tags/)
+response on 2026-07-12; recheck the endpoint before applying them if the
+dashboard rejects either value.
+
+## Apply to Chrome Web Store
+
+1. Run `npm run store:validate`, then open the extension in the
+   [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole).
+2. Open **Store listing**. Under **Product details**, set **Primary category**
+   to **Well-being**.
+3. Select each priority language from the language menu. Run
+   `npm run store:show -- <locale>` and paste **FULL DESCRIPTION** into
+   **Detailed description**. The package supplies the localized name and
+   summary; do not create a second summary in `metadata.json`.
+4. Under **Additional fields**, set **Homepage URL** to the canonical website
+   and **Support URL** to the canonical support URL. Verify the GitHub Pages
+   site in Search Console if needed, then select it from **Official URL**.
+5. Open **Privacy practices** and set the privacy-policy link to the canonical
+   privacy URL. Keep the data-use declarations consistent with the extension's
+   local-by-default storage and explicit opt-in browser-account sync.
+6. Save the draft, preview the localized listings, and submit the metadata
+   update for review.
+
+Chrome has no keyword or search-term field. Do not copy Edge search terms into
+the description; Chrome's policy treats keyword stuffing as spam.
+
+Official references:
+[Store listing tab](https://developer.chrome.com/docs/webstore/cws-dashboard-listing),
+[Privacy practices](https://developer.chrome.com/docs/webstore/cws-dashboard-privacy),
+and [category guidance](https://developer.chrome.com/docs/webstore/best-practices).
+
+## Apply to Microsoft Edge Add-ons
+
+1. Run `npm run store:validate`, then open Mortality in
+   [Partner Center](https://partner.microsoft.com/dashboard/microsoftedge/public/login?ref=dd).
+2. Open **Properties**. Set **Website** to the canonical website and
+   **Support contact detail** to the canonical support URL. Leave the Edge
+   category unchanged unless it is reviewed separately; `Well-being` is the
+   canonical Chrome category, not a cross-store category identifier.
+3. Open **Privacy** and set **Privacy policy** to the canonical privacy URL.
+   If the account still has the older form, set **Privacy policy URL** under
+   **Properties** instead.
+4. Open **Store listings**, then **Details for \<language\>** for every priority
+   locale. The uploaded package supplies the read-only extension name and
+   short description. Run `npm run store:show -- <locale>`, paste **FULL
+   DESCRIPTION** into the detailed description, and enter each **EDGE SEARCH
+   TERMS** item as one search term.
+5. Save each language, fix any Partner Center field errors, and submit the
+   updated listing for certification.
+
+The validator enforces Edge's documented detailed-description range of
+250–10,000 characters, maximum of 7 search terms, maximum of 30 characters per
+term, and maximum of 21 words across all terms.
+
+Official reference:
+[Publish a Microsoft Edge extension](https://learn.microsoft.com/en-us/microsoft-edge/extensions/publish/publish-extension).
+
+## Apply to Firefox Add-ons
+
+1. Run `npm run store:validate`, then open Mortality in the
+   [Add-ons Developer Hub](https://addons.mozilla.org/developers/).
+2. Open the add-on's product-page editor. For each priority locale, keep the
+   name as `Mortality`, copy **PACKAGE SUMMARY** to the localized summary, and
+   copy **FULL DESCRIPTION** to the localized description.
+3. Set **Homepage** to the canonical website, **Support site** to the canonical
+   support URL, and **Privacy policy** to the canonical privacy URL.
+4. Set the global tags to the **FIREFOX TAGS (GLOBAL)** values printed by
+   `store:show`. AMO tags are simple unlocalized strings, so do not translate
+   them per locale.
+5. Save the product-page changes and inspect the public localized pages.
+
+Official references:
+[Create an appealing listing](https://extensionworkshop.com/documentation/develop/create-an-appealing-listing/)
+and [AMO tag API](https://mozilla.github.io/addons-server/topics/api/tags.html).
+
+## Why listing updates remain manual
+
+The release workflow remains responsible only for immutable extension
+packages:
+
+- Chrome Web Store API v2 uploads, checks, and publishes package revisions.
+  Google notes that additional metadata still has to be supplied in the
+  Developer Dashboard.
+- The Edge Update REST API explicitly has no endpoint for product metadata such
+  as descriptions; those edits require Partner Center.
+- AMO documents an authenticated add-on metadata `PATCH`, but also states that
+  the API is not frozen and may change without warning. Its API key can act on
+  behalf of the developer account, and the documented edit payload does not
+  cover every required support/privacy field.
+
+Adding partial AMO-only automation would therefore expand secret scope while
+leaving the other stores and some AMO fields manual. Keep
+`.github/workflows/publish.yml` and `scripts/publish.sh` package-only, and apply
+this metadata through the dashboards.
+
+Official API references:
+[Chrome Web Store API v2](https://developer.chrome.com/blog/cws-api-v2),
+[Edge Update REST API](https://learn.microsoft.com/en-us/microsoft-edge/extensions/update/api/using-addons-api),
+[AMO add-on API](https://mozilla.github.io/addons-server/topics/api/addons.html),
+and [AMO authentication](https://mozilla.github.io/addons-server/topics/api/auth.html).

--- a/store-listing/README.md
+++ b/store-listing/README.md
@@ -1,8 +1,8 @@
 # Store listing metadata
 
 [`metadata.json`](metadata.json) is the source of truth for content managed in
-the Chrome Web Store, Microsoft Edge Add-ons, and Firefox Add-ons dashboards.
-It owns:
+the Chrome Web Store, Microsoft Edge Add-ons, and Firefox Add-ons listings. It
+owns:
 
 - the shared website, support, and privacy URLs;
 - the Chrome category;
@@ -15,7 +15,7 @@ metadata file. They resolve from `extName` and `extDescription` in
 `src/_locales/*/messages.json`, as referenced by `src/manifest.json`. This keeps
 all 55 package summaries in one place.
 
-Run the validator before editing a dashboard:
+Run the validator before publishing metadata or editing a dashboard:
 
 ```sh
 npm run store:validate
@@ -108,43 +108,88 @@ term, and maximum of 21 words across all terms.
 Official reference:
 [Publish a Microsoft Edge extension](https://learn.microsoft.com/en-us/microsoft-edge/extensions/publish/publish-extension).
 
-## Apply to Firefox Add-ons
+## Publish supported Firefox Add-ons fields
+
+AMO's authenticated v5 Edit endpoint supports the localized name, summary,
+description, and homepage plus global tags. The dependency-free publisher
+validates all canonical metadata before building that exact payload. It does not
+upload an extension package or include categories, screenshots, support URL, or
+privacy policy.
+
+Dry-run is the default and does not require credentials:
+
+```sh
+npm run --silent store:publish:firefox-metadata
+```
+
+The command prints the exact JSON `PATCH` payload. Repository locales map to AMO
+as follows: `en` → `en-US`, `de` → `de`, `es` → `es`, `fr` → `fr`, `ja` →
+`ja`, `pt_BR` → `pt-BR`, `zh_CN` → `zh-CN`, `zh_TW` → `zh-TW`, and `ko` →
+`ko`.
+
+Publishing requires an explicit flag and the same account-wide AMO credentials
+already used for Firefox package publishing:
+
+```sh
+FIREFOX_JWT_ISSUER=... \
+FIREFOX_JWT_SECRET=... \
+FIREFOX_ADDON_ID=... \
+npm run store:publish:firefox-metadata -- --apply
+```
+
+The manually dispatched `publish-firefox-metadata` Actions workflow also
+defaults to dry-run. Its apply mode only runs from the repository default branch
+and requires typing `PUBLISH FIREFOX METADATA`; only the apply job receives the
+existing Firefox secrets. This workflow is intentionally separate from release
+publishing because Chrome and Edge listing updates remain manual.
+
+**Translation review before production:** the eight non-English detailed
+descriptions and search-term sets are high-quality drafts, but they have not had
+native-speaker review. Native review is recommended before using either the
+apply command/workflow or entering this copy in any store dashboard.
+
+The publisher creates a short-lived HS256 JWT, URL-encodes the add-on ID, and
+sends one authenticated `PATCH` to
+`https://addons.mozilla.org/api/v5/addons/addon/{id}/`. It fails on any non-2xx
+response and redacts credentials and tokens from reported errors.
+
+## Complete the Firefox listing in the dashboard
 
 1. Run `npm run store:validate`, then open Mortality in the
    [Add-ons Developer Hub](https://addons.mozilla.org/developers/).
-2. Open the add-on's product-page editor. For each priority locale, keep the
-   name as `Mortality`, copy **PACKAGE SUMMARY** to the localized summary, and
-   copy **FULL DESCRIPTION** to the localized description.
-3. Set **Homepage** to the canonical website, **Support site** to the canonical
-   support URL, and **Privacy policy** to the canonical privacy URL.
-4. Set the global tags to the **FIREFOX TAGS (GLOBAL)** values printed by
-   `store:show`. AMO tags are simple unlocalized strings, so do not translate
-   them per locale.
-5. Save the product-page changes and inspect the public localized pages.
+2. Publish the API-supported fields with the command or manual workflow above,
+   then inspect the localized name, summary, description, homepage, and global
+   tags on the product-page editor.
+3. Set **Support site** to the canonical support URL and **Privacy policy** to
+   the canonical privacy URL. AMO's documented Edit payload does not expose
+   either field, so these remain dashboard updates.
+4. Save any dashboard changes and inspect the public localized pages.
 
 Official references:
 [Create an appealing listing](https://extensionworkshop.com/documentation/develop/create-an-appealing-listing/)
 and [AMO tag API](https://mozilla.github.io/addons-server/topics/api/tags.html).
 
-## Why listing updates remain manual
+## Automation boundaries
 
-The release workflow remains responsible only for immutable extension
-packages:
+Chrome and Edge listing metadata remains manual:
 
 - Chrome Web Store API v2 uploads, checks, and publishes package revisions.
   Google notes that additional metadata still has to be supplied in the
   Developer Dashboard.
 - The Edge Update REST API explicitly has no endpoint for product metadata such
   as descriptions; those edits require Partner Center.
-- AMO documents an authenticated add-on metadata `PATCH`, but also states that
-  the API is not frozen and may change without warning. Its API key can act on
-  behalf of the developer account, and the documented edit payload does not
-  cover every required support/privacy field.
 
-Adding partial AMO-only automation would therefore expand secret scope while
-leaving the other stores and some AMO fields manual. Keep
-`.github/workflows/publish.yml` and `scripts/publish.sh` package-only, and apply
-this metadata through the dashboards.
+AMO documents the authenticated metadata `PATCH` used by this tool, but the v5
+API is not frozen and may change without warning. AMO API credentials act on
+behalf of the developer account; this repository already stores the same
+account-wide issuer and secret for package publishing, so the metadata tool does
+not add credentials or expand secret availability. It does add another
+explicit, manual use of those credentials.
+
+Keep `.github/workflows/publish.yml` and `scripts/publish.sh` package-only.
+Firefox support and privacy URLs remain manual, and AMO metadata publishing must
+not be added to the automatic release path while the equivalent Chrome and Edge
+updates require dashboards.
 
 Official API references:
 [Chrome Web Store API v2](https://developer.chrome.com/blog/cws-api-v2),

--- a/store-listing/metadata.json
+++ b/store-listing/metadata.json
@@ -1,0 +1,238 @@
+{
+  "schemaVersion": 1,
+  "productName": "Mortality",
+  "summary": {
+    "catalogDirectory": "src/_locales",
+    "nameMessageKey": "extName",
+    "descriptionMessageKey": "extDescription"
+  },
+  "urls": {
+    "website": "https://alphabt.github.io/mortality/",
+    "support": "https://github.com/alphabt/mortality/issues",
+    "privacy": "https://alphabt.github.io/mortality/privacy.html"
+  },
+  "chrome": {
+    "category": "Well-being"
+  },
+  "firefox": {
+    "tags": ["dark mode", "privacy"]
+  },
+  "locales": {
+    "en": {
+      "storeLocales": {
+        "chrome": "en",
+        "edge": "en-US",
+        "firefox": "en-US"
+      },
+      "fullDescription": [
+        "Mortality replaces every new tab with a live counter of your age—a quiet memento mori designed to be read at a glance. It keeps time visible without turning it into a score, a streak, or an alarm.",
+        "Choose the view that feels useful:\n- fractional or calendar age\n- countdown to your next birthday\n- days or weeks lived\n- estimated years, days, or weeks remaining\n- lifetime progress and a life-in-weeks view",
+        "Make the page your own with carefully designed themes, custom colors, and numeral styles. The interface is available in 55 languages and supports keyboard use, screen readers, reduced motion, and contrast-checked themes.",
+        "Remaining-life views are actuarial estimates, not predictions. Use United Nations 2023 country-and-sex life tables, United States Social Security Administration 2023 data, or set a custom life expectancy.",
+        "Your birth details and preferences stay in browser storage by default. Browser-account sync is optional and only turns on when you explicitly enable it. Mortality requires no account and has no ads, analytics, tracking, or backend service.",
+        "Open a tab. See the number. Return to what matters."
+      ],
+      "edgeSearchTerms": [
+        "age counter",
+        "new tab",
+        "memento mori",
+        "life in weeks",
+        "life expectancy",
+        "mindfulness",
+        "birthday countdown"
+      ]
+    },
+    "de": {
+      "storeLocales": {
+        "chrome": "de",
+        "edge": "de-DE",
+        "firefox": "de"
+      },
+      "fullDescription": [
+        "Mortality verwandelt jeden neuen Tab in einen live mitlaufenden Zähler deines Alters – ein stilles Memento mori, das du auf einen Blick erfassen kannst. Es hält die Zeit sichtbar, ohne daraus einen Punktestand, eine Serie oder einen Alarm zu machen.",
+        "Wähle die Ansicht, die für dich sinnvoll ist:\n- Alter als Dezimalzahl oder im Kalenderformat\n- Countdown bis zu deinem nächsten Geburtstag\n- gelebte Tage oder Wochen\n- geschätzte verbleibende Jahre, Tage oder Wochen\n- Lebensfortschritt und eine Ansicht „Leben in Wochen“",
+        "Gestalte die Seite mit sorgfältig entworfenen Themes, individuellen Farben und Ziffernstilen ganz nach deinen Vorstellungen. Die Oberfläche ist in 55 Sprachen verfügbar und unterstützt Tastaturbedienung, Screenreader, reduzierte Bewegung und kontrastgeprüfte Themes.",
+        "Ansichten zur verbleibenden Lebenszeit sind versicherungsmathematische Schätzungen, keine Vorhersagen. Verwende die Sterbetafeln der Vereinten Nationen von 2023 nach Land und Geschlecht, die Daten der US-amerikanischen Sozialversicherungsbehörde (SSA) von 2023 oder eine selbst festgelegte Lebenserwartung.",
+        "Deine Geburtsdaten und Einstellungen bleiben standardmäßig lokal im Browserspeicher. Die Synchronisierung über dein Browserkonto ist optional und wird nur aktiviert, wenn du sie ausdrücklich einschaltest. Mortality benötigt kein Konto und kommt ohne Werbung, Analysen, Tracking oder Backend-Dienst aus.",
+        "Öffne einen Tab. Sieh die Zahl. Kehre zu dem zurück, was zählt."
+      ],
+      "edgeSearchTerms": [
+        "Alterszähler",
+        "Neuer Tab",
+        "Memento mori",
+        "Leben in Wochen",
+        "Lebenserwartung",
+        "Achtsamkeit",
+        "Geburtstags-Countdown"
+      ]
+    },
+    "es": {
+      "storeLocales": {
+        "chrome": "es",
+        "edge": "es-ES",
+        "firefox": "es"
+      },
+      "fullDescription": [
+        "Mortality convierte cada pestaña nueva en un contador en vivo de tu edad, un memento mori discreto pensado para leerse de un vistazo. Mantiene el tiempo visible sin convertirlo en una puntuación, una racha o una alarma.",
+        "Elige la vista que te resulte útil:\n- edad fraccionaria o por calendario\n- cuenta atrás hasta tu próximo cumpleaños\n- días o semanas vividos\n- años, días o semanas restantes estimados\n- progreso vital y una vista de la vida en semanas",
+        "Personaliza la página con temas cuidadosamente diseñados, colores personalizados y estilos numéricos. La interfaz está disponible en 55 idiomas y admite el uso con teclado, lectores de pantalla, movimiento reducido y temas con contraste verificado.",
+        "Las vistas de vida restante son estimaciones actuariales, no predicciones. Utiliza las tablas de vida de Naciones Unidas de 2023 por país y sexo, los datos de 2023 de la Administración del Seguro Social de EE. UU. (SSA), o define una esperanza de vida personalizada.",
+        "Tus datos de nacimiento y preferencias permanecen, por defecto, en el almacenamiento local del navegador. La sincronización mediante la cuenta del navegador es opcional y solo se activa si la habilitas expresamente. Mortality no requiere cuenta y no tiene anuncios, análisis, rastreo ni servicios de backend.",
+        "Abre una pestaña. Mira el número. Vuelve a lo que importa."
+      ],
+      "edgeSearchTerms": [
+        "contador de edad",
+        "nueva pestaña",
+        "memento mori",
+        "vida en semanas",
+        "esperanza de vida",
+        "atención plena",
+        "cuenta atrás cumpleaños"
+      ]
+    },
+    "fr": {
+      "storeLocales": {
+        "chrome": "fr",
+        "edge": "fr-FR",
+        "firefox": "fr"
+      },
+      "fullDescription": [
+        "Mortality transforme chaque nouvel onglet en un compteur d’âge en temps réel, un discret memento mori conçu pour se lire d’un coup d’œil. Il garde le temps visible sans en faire un score, une série ou une alarme.",
+        "Choisissez la vue qui vous convient :\n- âge fractionnaire ou calendaire\n- compte à rebours jusqu’à votre prochain anniversaire\n- jours ou semaines vécus\n- années, jours ou semaines restants estimés\n- progression de vie et une vue « vie en semaines »",
+        "Personnalisez la page avec des thèmes soigneusement conçus, des couleurs personnalisées et des styles de chiffres. L’interface est disponible en 55 langues et prend en charge la navigation au clavier, les lecteurs d’écran, la réduction des animations et des thèmes au contraste vérifié.",
+        "Les vues de vie restante sont des estimations actuarielles, pas des prédictions. Elles s’appuient sur les tables de mortalité des Nations unies 2023 par pays et par sexe, sur les données 2023 de la Social Security Administration américaine, ou sur une espérance de vie personnalisée que vous définissez.",
+        "Vos informations de naissance et vos préférences restent, par défaut, dans le stockage local du navigateur. La synchronisation via un compte navigateur est facultative et ne s’active que si vous la choisissez explicitement. Mortality ne nécessite aucun compte et fonctionne sans publicité, analyse d’usage, suivi ni service backend.",
+        "Ouvrez un onglet. Regardez le nombre. Revenez à l’essentiel."
+      ],
+      "edgeSearchTerms": [
+        "compteur d’âge",
+        "nouvel onglet",
+        "memento mori",
+        "vie en semaines",
+        "espérance de vie",
+        "pleine conscience",
+        "compte à rebours anniversaire"
+      ]
+    },
+    "ja": {
+      "storeLocales": {
+        "chrome": "ja",
+        "edge": "ja-JP",
+        "firefox": "ja"
+      },
+      "fullDescription": [
+        "Mortalityは、新しいタブを開くたびにあなたの年齢をリアルタイムで刻むカウンターに変えます。一目で読み取れるように設計された、静かなメメント・モリです。時間の経過を見える形にしながらも、得点や連続記録、警告には変えません。",
+        "役に立つと感じる表示を選べます：\n- 小数または年月日で表す年齢\n- 次の誕生日までのカウントダウン\n- これまで生きた日数・週数\n- 推定される残りの年数・日数・週数\n- 生涯の進捗率と「人生を週で見る」表示",
+        "丁寧に作られたテーマ、カスタムカラー、数字スタイルで、ページを自分好みに仕立てられます。インターフェースは55言語に対応し、キーボード操作、スクリーンリーダー、モーション低減設定、コントラスト検証済みのテーマもサポートしています。",
+        "残りの人生に関する表示は、予測ではなく保険数理上の推定値です。国連の2023年版・国と性別ごとの生命表、米国社会保障局（SSA）の2023年データ、または自分で設定した平均寿命を使用できます。",
+        "生年月日の情報や設定は、初期状態ではブラウザ内にローカル保存されます。ブラウザアカウントによる同期は任意で、明示的に有効にした場合のみ機能します。Mortalityにはアカウントは不要で、広告、アナリティクス、トラッキング、バックエンドサービスはありません。",
+        "タブを開く。数字を見る。大切なことに戻る。"
+      ],
+      "edgeSearchTerms": [
+        "年齢カウンター",
+        "新しいタブ",
+        "メメント・モリ",
+        "人生を週で表示",
+        "平均寿命",
+        "マインドフルネス",
+        "誕生日カウントダウン"
+      ]
+    },
+    "pt_BR": {
+      "storeLocales": {
+        "chrome": "pt_BR",
+        "edge": "pt-BR",
+        "firefox": "pt-BR"
+      },
+      "fullDescription": [
+        "O Mortality transforma cada nova guia em um contador da sua idade em tempo real — um memento mori discreto, pensado para ser lido num piscar de olhos. Ele mantém o tempo visível sem transformá-lo em pontuação, sequência ou alarme.",
+        "Escolha a visualização que fizer mais sentido para você:\n- idade fracionária ou por calendário\n- contagem regressiva até seu próximo aniversário\n- dias ou semanas vividos\n- anos, dias ou semanas restantes estimados\n- progresso de vida e uma visualização da vida em semanas",
+        "Personalize a página com temas cuidadosamente elaborados, cores personalizadas e estilos numéricos. A interface está disponível em 55 idiomas e é compatível com uso pelo teclado, leitores de tela, redução de movimento e temas com contraste verificado.",
+        "As visualizações de vida restante são estimativas atuariais, não previsões. Elas usam as tábuas de mortalidade da ONU de 2023 por país e sexo, os dados de 2023 da Social Security Administration dos EUA ou uma expectativa de vida personalizada definida por você.",
+        "Seus dados de nascimento e preferências ficam, por padrão, no armazenamento local do navegador. A sincronização pela conta do navegador é opcional e só é ativada quando você a habilita explicitamente. O Mortality não exige conta e não tem anúncios, análise de uso, rastreamento ou serviço de backend.",
+        "Abra uma guia. Veja o número. Volte para o que importa."
+      ],
+      "edgeSearchTerms": [
+        "contador de idade",
+        "nova guia",
+        "memento mori",
+        "vida em semanas",
+        "expectativa de vida",
+        "atenção plena",
+        "contagem para aniversário"
+      ]
+    },
+    "zh_CN": {
+      "storeLocales": {
+        "chrome": "zh_CN",
+        "edge": "zh-CN",
+        "firefox": "zh-CN"
+      },
+      "fullDescription": [
+        "Mortality 会把每个新标签页变成实时显示你年龄的计数器——一份一眼就能读懂的安静生命提醒。它让时间清晰可见，却不会把时间变成分数、连续打卡或警报。",
+        "选择对你有用的视图：\n- 小数年龄或日历年龄\n- 下一个生日倒计时\n- 已度过的天数或周数\n- 预计剩余的年数、天数或周数\n- 一生进度和“人生周历”视图",
+        "用精心设计的主题、自定义颜色和数字字体风格，让页面更符合你的喜好。界面支持55种语言，并兼容键盘操作、屏幕阅读器、减弱动效以及经过对比度检验的主题。",
+        "剩余寿命视图只是精算估计，并非预测。你可以使用联合国2023年按国家和性别划分的生命表、美国社会保障局（SSA）2023年数据，或者自行设置预期寿命。",
+        "你的出生信息和偏好设置默认只保存在浏览器本地存储中。浏览器账户同步是可选功能，只有在你明确开启后才会启用。Mortality 不需要账户，也没有广告、数据分析、跟踪或后端服务。",
+        "打开一个标签页。看一眼数字。回到真正重要的事。"
+      ],
+      "edgeSearchTerms": [
+        "年龄计数器",
+        "新标签页",
+        "生命提醒",
+        "人生周历",
+        "预期寿命",
+        "正念",
+        "生日倒计时"
+      ]
+    },
+    "zh_TW": {
+      "storeLocales": {
+        "chrome": "zh_TW",
+        "edge": "zh-TW",
+        "firefox": "zh-TW"
+      },
+      "fullDescription": [
+        "Mortality 會把每個新分頁變成即時顯示你年齡的計數器——一份一眼就能讀懂的安靜生命提醒。它讓時間清楚可見，卻不會把時間變成分數、連續紀錄或警示。",
+        "選擇對你有用的檢視方式：\n- 小數年齡或日曆年齡\n- 距下一個生日的倒數計時\n- 已經度過的天數或週數\n- 預估剩餘的年數、天數或週數\n- 一生進度和「人生週曆」檢視",
+        "透過精心設計的主題、自訂顏色與數字字型樣式，讓頁面更貼近你的喜好。介面支援55種語言，並相容鍵盤操作、螢幕閱讀器、減少動態效果，以及經過對比度檢核的主題。",
+        "剩餘壽命檢視只是精算估計，並非預測。你可以選用聯合國2023年依國家與性別劃分的生命表、美國社會安全局（SSA）2023年資料，或自行設定預期壽命。",
+        "你的出生資訊與偏好設定，預設只會保存在瀏覽器的本機儲存空間中。瀏覽器帳號同步是選用功能，僅在你明確啟用後才會生效。Mortality 不需要帳號，也沒有廣告、分析、追蹤或後端服務。",
+        "打開一個分頁。看一眼數字。回到真正重要的事。"
+      ],
+      "edgeSearchTerms": [
+        "年齡計數器",
+        "新分頁",
+        "生命提醒",
+        "人生週曆",
+        "預期壽命",
+        "正念",
+        "生日倒數"
+      ]
+    },
+    "ko": {
+      "storeLocales": {
+        "chrome": "ko",
+        "edge": "ko-KR",
+        "firefox": "ko"
+      },
+      "fullDescription": [
+        "Mortality는 새 탭을 열 때마다 나이를 실시간으로 보여주는 카운터로 바꿉니다. 한눈에 읽히도록 설계된 조용한 메멘토 모리입니다. 시간을 점수나 연속 기록, 경고로 만들지 않으면서도 눈에 보이게 합니다.",
+        "필요에 맞는 보기를 선택하세요:\n- 소수 또는 달력 기준으로 표시한 나이\n- 다음 생일까지 남은 시간 카운트다운\n- 지금까지 살아온 일수 또는 주 수\n- 남은 것으로 추정되는 연수, 일수 또는 주 수\n- 생애 진행률과 ‘주 단위로 보는 인생’ 보기",
+        "정성껏 디자인한 테마, 사용자 지정 색상, 숫자 스타일로 화면을 원하는 모습으로 꾸밀 수 있습니다. 인터페이스는 55개 언어를 지원하며, 키보드 사용, 스크린 리더, 동작 축소, 대비를 검증한 테마도 지원합니다.",
+        "남은 삶에 관한 보기는 예측이 아니라 보험계리학적 추정치입니다. 유엔의 2023년 국가·성별 생명표, 미국 사회보장국(SSA)의 2023년 데이터 또는 직접 설정한 기대 수명을 사용할 수 있습니다.",
+        "생년월일 정보와 설정값은 기본적으로 브라우저 저장소에만 남습니다. 브라우저 계정 동기화는 선택 사항이며, 사용자가 명시적으로 켰을 때만 작동합니다. Mortality는 계정이 필요 없으며 광고, 분석, 추적 또는 백엔드 서비스가 없습니다.",
+        "탭을 엽니다. 숫자를 봅니다. 중요한 것으로 돌아갑니다."
+      ],
+      "edgeSearchTerms": [
+        "나이 카운터",
+        "새 탭",
+        "메멘토 모리",
+        "인생 주간 보기",
+        "기대 수명",
+        "마음챙김",
+        "생일 카운트다운"
+      ]
+    }
+  }
+}

--- a/test/publish-firefox-metadata.test.js
+++ b/test/publish-firefox-metadata.test.js
@@ -86,7 +86,9 @@ describe("Firefox listing metadata payload", () => {
     const payload = loadAmoMetadataPayload(ROOT);
 
     for (const field of ["name", "summary", "description", "homepage"]) {
-      expect(Object.keys(payload[field])).toEqual(expectedAmoLocales);
+      expect(Object.keys(payload[field]).sort()).toEqual(
+        [...expectedAmoLocales].sort(),
+      );
     }
   });
 

--- a/test/publish-firefox-metadata.test.js
+++ b/test/publish-firefox-metadata.test.js
@@ -1,0 +1,277 @@
+import { createHmac } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAmoEndpoint,
+  createAmoJwt,
+  loadAmoMetadataPayload,
+  publishAmoMetadata,
+  requireAmoCredentials,
+  validateAndBuildAmoPayload,
+} from "../scripts/publish-firefox-metadata.mjs";
+import {
+  loadStoreMetadata,
+  renderFullDescription,
+  validateStoreMetadata,
+} from "../scripts/validate-store-metadata.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCRIPT = join(ROOT, "scripts", "publish-firefox-metadata.mjs");
+const WORKFLOW = readFileSync(
+  join(ROOT, ".github", "workflows", "publish-firefox-metadata.yml"),
+  "utf8",
+);
+const metadata = loadStoreMetadata(ROOT);
+const validation = validateStoreMetadata(metadata, { root: ROOT });
+const expectedAmoLocales = [
+  "en-US",
+  "de",
+  "es",
+  "fr",
+  "ja",
+  "pt-BR",
+  "zh-CN",
+  "zh-TW",
+  "ko",
+];
+
+function environmentWithoutFirefoxCredentials() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([name]) => !name.startsWith("FIREFOX_"),
+    ),
+  );
+}
+
+function decodeJson(segment) {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+}
+
+describe("Firefox listing metadata payload", () => {
+  it("contains only officially writable fields with the exact canonical copy", () => {
+    const payload = loadAmoMetadataPayload(ROOT);
+
+    expect(Object.keys(payload)).toEqual([
+      "name",
+      "summary",
+      "description",
+      "homepage",
+      "tags",
+    ]);
+    expect(payload.tags).toEqual(metadata.firefox.tags);
+
+    for (const [repositoryLocale, localeMetadata] of Object.entries(
+      metadata.locales,
+    )) {
+      const amoLocale = localeMetadata.storeLocales.firefox;
+      expect(payload.name[amoLocale]).toBe(metadata.productName);
+      expect(payload.summary[amoLocale]).toBe(
+        validation.summaries[repositoryLocale],
+      );
+      expect(payload.description[amoLocale]).toBe(
+        renderFullDescription(localeMetadata),
+      );
+      expect(payload.homepage[amoLocale]).toBe(metadata.urls.website);
+    }
+
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain(metadata.urls.support);
+    expect(serialized).not.toContain(metadata.urls.privacy);
+  });
+
+  it("maps repository locales to the expected AMO locale codes", () => {
+    const payload = loadAmoMetadataPayload(ROOT);
+
+    for (const field of ["name", "summary", "description", "homepage"]) {
+      expect(Object.keys(payload[field])).toEqual(expectedAmoLocales);
+    }
+  });
+
+  it("blocks publishing when canonical metadata is malformed", () => {
+    const invalid = structuredClone(metadata);
+    delete invalid.locales.fr.storeLocales.firefox;
+
+    expect(() => validateAndBuildAmoPayload(invalid, { root: ROOT })).toThrow(
+      'Store metadata validation failed:\n- metadata.locales.fr.storeLocales is missing "firefox"',
+    );
+  });
+
+  it("prints the exact payload in dry-run mode without credentials", () => {
+    const result = spawnSync(process.execPath, [SCRIPT], {
+      cwd: ROOT,
+      env: environmentWithoutFirefoxCredentials(),
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual(loadAmoMetadataPayload(ROOT));
+  });
+
+  it("requires all existing Firefox credentials when applying", () => {
+    const result = spawnSync(process.execPath, [SCRIPT, "--apply"], {
+      cwd: ROOT,
+      env: environmentWithoutFirefoxCredentials(),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "--apply requires the following environment variables: FIREFOX_JWT_ISSUER, FIREFOX_JWT_SECRET, FIREFOX_ADDON_ID",
+    );
+  });
+
+  it("trims validated credentials before using them", () => {
+    expect(
+      requireAmoCredentials({
+        FIREFOX_JWT_ISSUER: "  user:123:456\n",
+        FIREFOX_JWT_SECRET: "\tapi-secret  ",
+        FIREFOX_ADDON_ID: " mortality@example.com\n",
+      }),
+    ).toEqual({
+      issuer: "user:123:456",
+      secret: "api-secret",
+      addonId: "mortality@example.com",
+    });
+  });
+});
+
+describe("AMO authentication and request safety", () => {
+  it("creates a short-lived, correctly signed HS256 JWT", () => {
+    const issuer = "user:123:456";
+    const secret = "test-api-secret";
+    const token = createAmoJwt({
+      issuer,
+      secret,
+      issuedAt: 1_700_000_000,
+      jwtId: "unique-jwt-id",
+    });
+    const [encodedHeader, encodedClaims, signature] = token.split(".");
+    const signingInput = `${encodedHeader}.${encodedClaims}`;
+
+    expect(decodeJson(encodedHeader)).toEqual({ alg: "HS256", typ: "JWT" });
+    expect(decodeJson(encodedClaims)).toEqual({
+      iss: issuer,
+      jti: "unique-jwt-id",
+      iat: 1_700_000_000,
+      exp: 1_700_000_060,
+    });
+    expect(signature).toBe(
+      createHmac("sha256", secret).update(signingInput).digest("base64url"),
+    );
+  });
+
+  it("URL-encodes the add-on identifier and sends the exact PATCH body", async () => {
+    const payload = loadAmoMetadataPayload(ROOT);
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => "",
+    });
+    const addonId = "mortality/test@example.com?channel=listed";
+
+    await expect(
+      publishAmoMetadata({
+        payload,
+        issuer: "issuer",
+        secret: "secret",
+        addonId,
+        fetchImpl,
+        issuedAt: 1_700_000_000,
+        jwtId: "request-id",
+      }),
+    ).resolves.toBe(204);
+
+    expect(buildAmoEndpoint(addonId)).toBe(
+      "https://addons.mozilla.org/api/v5/addons/addon/mortality%2Ftest%40example.com%3Fchannel%3Dlisted/",
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, request] = fetchImpl.mock.calls[0];
+    expect(url).toBe(buildAmoEndpoint(addonId));
+    expect(request.method).toBe("PATCH");
+    expect(request.headers.Accept).toBe("application/json");
+    expect(request.headers["Content-Type"]).toBe("application/json");
+    expect(request.headers.Authorization).toMatch(/^JWT [^.]+\.[^.]+\.[^.]+$/u);
+    expect(JSON.parse(request.body)).toEqual(payload);
+  });
+
+  it("fails loudly on HTTP errors while redacting credentials and tokens", async () => {
+    const issuer = "sensitive-issuer";
+    const secret = "sensitive-secret";
+    const fetchImpl = vi.fn(async (_url, request) => ({
+      ok: false,
+      status: 403,
+      text: async () =>
+        `denied issuer=${issuer} secret=${secret} auth=${request.headers.Authorization}`,
+    }));
+
+    let failure;
+    try {
+      await publishAmoMetadata({
+        payload: loadAmoMetadataPayload(ROOT),
+        issuer,
+        secret,
+        addonId: "mortality@example.com",
+        fetchImpl,
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure.message).toContain(
+      "AMO metadata update failed with HTTP 403",
+    );
+    expect(failure.message).toContain("[REDACTED]");
+    expect(failure.message).not.toContain(issuer);
+    expect(failure.message).not.toContain(secret);
+    const token = fetchImpl.mock.calls[0][1].headers.Authorization.slice(4);
+    expect(failure.message).not.toContain(token);
+  });
+
+  it("redacts credentials from transport failures", async () => {
+    const secret = "transport-secret";
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error(`failure: ${secret}`));
+
+    await expect(
+      publishAmoMetadata({
+        payload: loadAmoMetadataPayload(ROOT),
+        issuer: "issuer",
+        secret,
+        addonId: "mortality@example.com",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("AMO metadata request failed: failure: [REDACTED]");
+  });
+});
+
+describe("Firefox metadata workflow safety", () => {
+  it("keeps dry-run ref-independent and blocks apply outside the default branch", () => {
+    const dryRunJob = WORKFLOW.slice(
+      WORKFLOW.indexOf("  dry-run:\n"),
+      WORKFLOW.indexOf("  apply:\n"),
+    );
+    const applyJob = WORKFLOW.slice(WORKFLOW.indexOf("  apply:\n"));
+
+    expect(dryRunJob).not.toContain("github.ref_name");
+    expect(dryRunJob).not.toContain("default_branch");
+    expect(dryRunJob).not.toContain("secrets.FIREFOX_");
+
+    expect(applyJob).toContain("SELECTED_REF: ${{ github.ref_name }}");
+    expect(applyJob).toContain(
+      "DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
+    );
+    expect(applyJob).toContain(
+      'if [ "$SELECTED_REF" != "$DEFAULT_BRANCH" ]; then',
+    );
+    expect(
+      applyJob.indexOf("github.event.repository.default_branch"),
+    ).toBeLessThan(applyJob.indexOf("secrets.FIREFOX_JWT_ISSUER"));
+  });
+});

--- a/test/store-metadata.test.js
+++ b/test/store-metadata.test.js
@@ -1,0 +1,140 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  PRIORITY_LOCALES,
+  loadStoreMetadata,
+  renderFullDescription,
+  validateStoreMetadata,
+} from "../scripts/validate-store-metadata.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCRIPT = join(ROOT, "scripts", "validate-store-metadata.mjs");
+const metadata = loadStoreMetadata(ROOT);
+
+function cloneMetadata() {
+  return structuredClone(metadata);
+}
+
+describe("canonical store listing metadata", () => {
+  it("passes schema, locale, limit, URL, and package-summary validation", () => {
+    const result = validateStoreMetadata(metadata, { root: ROOT });
+
+    expect(result.errors).toEqual([]);
+    expect(result.catalogCount).toBe(55);
+    expect(Object.keys(metadata.locales).sort()).toEqual(
+      [...PRIORITY_LOCALES].sort(),
+    );
+
+    for (const locale of PRIORITY_LOCALES) {
+      const catalog = JSON.parse(
+        readFileSync(
+          join(ROOT, "src", "_locales", locale, "messages.json"),
+          "utf8",
+        ),
+      );
+      expect(result.summaries[locale]).toBe(
+        catalog[metadata.summary.descriptionMessageKey].message,
+      );
+      expect(renderFullDescription(metadata.locales[locale])).toContain(
+        "Mortality",
+      );
+    }
+  });
+
+  it("rejects missing priority locales, forbidden copy, and URL drift", () => {
+    const invalid = cloneMetadata();
+    delete invalid.locales.ko;
+    invalid.locales.en.fullDescription[0] += " Death-clock positioning.";
+    invalid.urls.support = "http://example.com/support";
+
+    const errors = validateStoreMetadata(invalid, { root: ROOT }).errors.join(
+      "\n",
+    );
+    expect(errors).toContain('missing priority locale "ko"');
+    expect(errors).toContain('forbidden phrase "death clock"');
+    expect(errors).toContain(
+      "metadata.urls.support must be https://github.com/alphabt/mortality/issues",
+    );
+    expect(errors).toContain("metadata.urls.support must use HTTPS");
+  });
+
+  it("enforces description and Edge search-term limits", () => {
+    const invalid = cloneMetadata();
+    invalid.locales.en.fullDescription = ["Too short for a store listing."];
+    invalid.locales.de.edgeSearchTerms = [
+      "eins",
+      "zwei",
+      "drei",
+      "vier",
+      "fünf",
+      "sechs",
+      "sieben",
+      "acht",
+    ];
+    invalid.locales.es.edgeSearchTerms = [
+      "uno dos tres cuatro cinco seis siete ocho nueve diez once doce trece catorce quince dieciséis diecisiete dieciocho diecinueve veinte veintiuno veintidós",
+    ];
+
+    const errors = validateStoreMetadata(invalid, { root: ROOT }).errors.join(
+      "\n",
+    );
+    expect(errors).toContain("250-character minimum");
+    expect(errors).toContain("7-term maximum");
+    expect(errors).toContain("30-character maximum");
+    expect(errors).toContain("21-word maximum");
+  });
+
+  it("reports malformed schema without throwing", () => {
+    const invalid = cloneMetadata();
+    delete invalid.summary.catalogDirectory;
+    invalid.locales.en.unexpected = true;
+
+    expect(() => validateStoreMetadata(invalid, { root: ROOT })).not.toThrow();
+    const errors = validateStoreMetadata(invalid, { root: ROOT }).errors.join(
+      "\n",
+    );
+    expect(errors).toContain('metadata.summary is missing "catalogDirectory"');
+    expect(errors).toContain(
+      'metadata.locales.en has unknown field "unexpected"',
+    );
+  });
+
+  it("rejects unsupported Firefox tags and invalid store locale mappings", () => {
+    const invalid = cloneMetadata();
+    invalid.firefox.tags = ["not-a-real-tag"];
+    invalid.locales.pt_BR.storeLocales.edge = "pt-BRR";
+    invalid.locales.zh_CN.storeLocales.firefox = "zh-CNN";
+
+    const errors = validateStoreMetadata(invalid, { root: ROOT }).errors.join(
+      "\n",
+    );
+    expect(errors).toContain("not in Firefox's allowed tag vocabulary");
+    expect(errors).toContain(
+      'metadata.locales.pt_BR.storeLocales.edge must be "pt-BR"',
+    );
+    expect(errors).toContain(
+      'metadata.locales.zh_CN.storeLocales.firefox must be "zh-CN"',
+    );
+  });
+
+  it("prints dashboard-ready localized copy without duplicating summaries", () => {
+    const result = spawnSync(process.execPath, [SCRIPT, "--locale", "de"], {
+      cwd: ROOT,
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("PACKAGE SUMMARY");
+    expect(result.stdout).toContain(
+      "Mach jeden neuen Tab zu einem Live-Zähler deines Alters",
+    );
+    expect(result.stdout).toContain("FULL DESCRIPTION");
+    expect(result.stdout).toContain("EDGE SEARCH TERMS");
+    expect(result.stdout).toContain(
+      "https://alphabt.github.io/mortality/privacy.html",
+    );
+  });
+});

--- a/test/store-metadata.test.js
+++ b/test/store-metadata.test.js
@@ -1,12 +1,14 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   PRIORITY_LOCALES,
   loadStoreMetadata,
   renderFullDescription,
+  runCli,
   validateStoreMetadata,
 } from "../scripts/validate-store-metadata.mjs";
 
@@ -138,5 +140,30 @@ describe("canonical store listing metadata", () => {
     expect(result.stdout).toContain(
       "https://alphabt.github.io/mortality/privacy.html",
     );
+  });
+
+  it("prints the underlying metadata read error", () => {
+    const temp = mkdtempSync(join(tmpdir(), "mortality-store-metadata-"));
+    const malformed = join(temp, "metadata.json");
+    writeFileSync(malformed, "{");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const previousExitCode = process.exitCode;
+
+    try {
+      process.exitCode = undefined;
+      runCli(malformed);
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "store-listing/metadata.json is not readable JSON",
+        ),
+      );
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode;
+      consoleError.mockRestore();
+      rmSync(temp, { recursive: true, force: true });
+    }
   });
 });

--- a/test/store-metadata.test.js
+++ b/test/store-metadata.test.js
@@ -64,6 +64,7 @@ describe("canonical store listing metadata", () => {
   it("enforces description and Edge search-term limits", () => {
     const invalid = cloneMetadata();
     invalid.locales.en.fullDescription = ["Too short for a store listing."];
+    invalid.locales.fr.fullDescription[0] += " ";
     invalid.locales.de.edgeSearchTerms = [
       "eins",
       "zwei",
@@ -82,6 +83,7 @@ describe("canonical store listing metadata", () => {
       "\n",
     );
     expect(errors).toContain("250-character minimum");
+    expect(errors).toContain("trimmed, non-empty paragraphs");
     expect(errors).toContain("7-term maximum");
     expect(errors).toContain("30-character maximum");
     expect(errors).toContain("21-word maximum");


### PR DESCRIPTION
## Summary

- add `store-listing/metadata.json` as the canonical source for shared URLs, Chrome's Well-being category, nine localized detailed descriptions, localized Edge search terms, and Firefox tags
- resolve names and package summaries from the existing `src/_locales/*/messages.json` catalogs instead of duplicating them
- add a dependency-free validator and dashboard-ready locale printer with schema, coverage, limits, URL, forbidden-copy, tag-vocabulary, locale-mapping, and manifest/catalog parity checks
- document exact Chrome, Edge, and Firefox dashboard steps plus the official API boundary

## Listing changes

The new copy presents Mortality as a quiet live age counter and memento mori, then describes fractional and calendar age, the next-birthday countdown, lived and remaining time views, lifetime progress, life in weeks, themes and numeral customization, 55 languages, accessibility, actuarial data sources, local-by-default storage, and explicit opt-in browser-account sync. It also states that Mortality has no account, ads, analytics, tracking, or backend.

Chrome moves from Workflow & Planning to Well-being. Edge receives seven natural search terms per priority locale. Firefox uses the currently supported global `dark mode` and `privacy` tags. No images or runtime UI are changed.

## Stack relationship

The intended base, summary-copy PR #73, was squash-merged and its branch deleted while this layer was in progress. Following the repository's stacked-PR guidance, this commit was replayed onto the current `main`; the diff contains only this layer.

## Automation decision

Chrome Web Store API v2 and the Edge Update REST API publish packages but do not update listing metadata. AMO exposes an authenticated metadata API, but its official docs say it is unfrozen, its JWT credential acts on behalf of the developer account, and the edit payload does not cover every required support/privacy field. Existing release automation therefore remains package-only; dashboard application is explicit in `store-listing/README.md`.

## Manual dashboard work after merge

- Chrome: apply all nine detailed descriptions, set category to Well-being, set homepage/support/privacy URLs, and select the verified official URL; Chrome has no keyword field.
- Edge: apply all nine detailed descriptions and localized search terms, then set website/support/privacy URLs.
- Firefox: apply localized summaries and descriptions, set homepage/support/privacy URLs, and select the global tags.

The localized descriptions are publication-ready drafts but have not received native-speaker review; a native review is recommended before pasting them into production dashboards.

## Validation

- `npm test`
- `npm run format:check`
- `npm run zip`
