### PR TITLE
Add opt-in Firefox listing metadata publishing

### DIFF
--- a/.github/workflows/publish-firefox-metadata.yml
+++ b/.github/workflows/publish-firefox-metadata.yml
@@ -1,0 +1,66 @@
+name: "publish-firefox-metadata"
+
+# Listing metadata stays separate from release/package publishing so an AMO
+# update cannot silently drift ahead of the manual Chrome and Edge listings.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Print the payload, or publish it to the Firefox listing"
+        type: choice
+        options:
+          - dry-run
+          - apply
+        default: dry-run
+        required: true
+      confirmation:
+        description: "For apply mode only, type PUBLISH FIREFOX METADATA"
+        type: string
+        default: ""
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-firefox-metadata
+  cancel-in-progress: false
+
+jobs:
+  dry-run:
+    name: "Show AMO metadata payload"
+    if: inputs.mode == 'dry-run'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+      - run: npm run --silent store:publish:firefox-metadata
+
+  apply:
+    name: "Publish AMO metadata"
+    if: inputs.mode == 'apply'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require explicit confirmation
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          if [ "$CONFIRMATION" != "PUBLISH FIREFOX METADATA" ]; then
+            echo "::error::Type PUBLISH FIREFOX METADATA to confirm apply mode."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Publish supported listing fields
+        env:
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+          FIREFOX_ADDON_ID: ${{ secrets.FIREFOX_ADDON_ID }}
+        run: npm run store:publish:firefox-metadata -- --apply

--- a/.github/workflows/publish-firefox-metadata.yml
+++ b/.github/workflows/publish-firefox-metadata.yml
@@ -44,10 +44,16 @@ jobs:
     if: inputs.mode == 'apply'
     runs-on: ubuntu-latest
     steps:
-      - name: Require explicit confirmation
+      - name: Require default branch and explicit confirmation
         env:
+          SELECTED_REF: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           CONFIRMATION: ${{ inputs.confirmation }}
         run: |
+          if [ "$SELECTED_REF" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::Apply mode must run from the repository default branch ($DEFAULT_BRANCH), not $SELECTED_REF."
+            exit 1
+          fi
           if [ "$CONFIRMATION" != "PUBLISH FIREFOX METADATA" ]; then
             echo "::error::Type PUBLISH FIREFOX METADATA to confirm apply mode."
             exit 1

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "store:validate": "node scripts/validate-store-metadata.mjs",
-    "store:show": "node scripts/validate-store-metadata.mjs --locale"
+    "store:show": "node scripts/validate-store-metadata.mjs --locale",
+    "store:publish:firefox-metadata": "node scripts/publish-firefox-metadata.mjs"
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^4.1.10",

--- a/scripts/publish-firefox-metadata.mjs
+++ b/scripts/publish-firefox-metadata.mjs
@@ -124,8 +124,8 @@ export function requireAmoCredentials(environment) {
   }
 
   return {
-    issuer: environment.FIREFOX_JWT_ISSUER,
-    secret: environment.FIREFOX_JWT_SECRET,
+    issuer: environment.FIREFOX_JWT_ISSUER.trim(),
+    secret: environment.FIREFOX_JWT_SECRET.trim(),
     addonId: environment.FIREFOX_ADDON_ID.trim(),
   };
 }

--- a/scripts/publish-firefox-metadata.mjs
+++ b/scripts/publish-firefox-metadata.mjs
@@ -1,0 +1,228 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  loadStoreMetadata,
+  renderFullDescription,
+  validateStoreMetadata,
+} from "./validate-store-metadata.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export const AMO_API_BASE = "https://addons.mozilla.org/api/v5/addons/addon";
+
+function encodeJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function redact(value, sensitiveValues) {
+  let redacted = String(value);
+  for (const sensitiveValue of sensitiveValues) {
+    if (sensitiveValue) {
+      redacted = redacted.replaceAll(sensitiveValue, "[REDACTED]");
+    }
+  }
+  return redacted;
+}
+
+export function createAmoJwt({
+  issuer,
+  secret,
+  issuedAt = Math.floor(Date.now() / 1000),
+  jwtId = randomUUID(),
+}) {
+  const header = { alg: "HS256", typ: "JWT" };
+  const claims = {
+    iss: issuer,
+    jti: jwtId,
+    iat: issuedAt,
+    exp: issuedAt + 60,
+  };
+  const signingInput = `${encodeJson(header)}.${encodeJson(claims)}`;
+  const signature = createHmac("sha256", secret)
+    .update(signingInput)
+    .digest("base64url");
+
+  return `${signingInput}.${signature}`;
+}
+
+export function buildAmoMetadataPayload(metadata, summaries) {
+  const name = {};
+  const summary = {};
+  const description = {};
+  const homepage = {};
+
+  for (const [repositoryLocale, localeMetadata] of Object.entries(
+    metadata.locales,
+  )) {
+    const amoLocale = localeMetadata.storeLocales.firefox;
+    const localizedSummary = summaries[repositoryLocale];
+    if (!localizedSummary) {
+      throw new Error(
+        `Validated package summary is missing for locale "${repositoryLocale}"`,
+      );
+    }
+
+    name[amoLocale] = metadata.productName;
+    summary[amoLocale] = localizedSummary;
+    description[amoLocale] = renderFullDescription(localeMetadata);
+    homepage[amoLocale] = metadata.urls.website;
+  }
+
+  return {
+    name,
+    summary,
+    description,
+    homepage,
+    tags: [...metadata.firefox.tags],
+  };
+}
+
+export function validateAndBuildAmoPayload(metadata, { root = ROOT } = {}) {
+  const validation = validateStoreMetadata(metadata, { root });
+  if (validation.errors.length > 0) {
+    throw new Error(
+      `Store metadata validation failed:\n${validation.errors
+        .map((error) => `- ${error}`)
+        .join("\n")}`,
+    );
+  }
+
+  return buildAmoMetadataPayload(metadata, validation.summaries);
+}
+
+export function loadAmoMetadataPayload(root = ROOT) {
+  let metadata;
+  try {
+    metadata = loadStoreMetadata(root);
+  } catch (error) {
+    throw new Error(
+      `Unable to load canonical store metadata: ${error.message}`,
+    );
+  }
+  return validateAndBuildAmoPayload(metadata, { root });
+}
+
+export function buildAmoEndpoint(addonId, apiBase = AMO_API_BASE) {
+  return `${apiBase.replace(/\/+$/u, "")}/${encodeURIComponent(addonId)}/`;
+}
+
+export function requireAmoCredentials(environment) {
+  const names = [
+    "FIREFOX_JWT_ISSUER",
+    "FIREFOX_JWT_SECRET",
+    "FIREFOX_ADDON_ID",
+  ];
+  const missing = names.filter(
+    (name) =>
+      typeof environment[name] !== "string" || environment[name].trim() === "",
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `--apply requires the following environment variables: ${missing.join(", ")}`,
+    );
+  }
+
+  return {
+    issuer: environment.FIREFOX_JWT_ISSUER,
+    secret: environment.FIREFOX_JWT_SECRET,
+    addonId: environment.FIREFOX_ADDON_ID.trim(),
+  };
+}
+
+export async function publishAmoMetadata({
+  payload,
+  issuer,
+  secret,
+  addonId,
+  fetchImpl = globalThis.fetch,
+  apiBase = AMO_API_BASE,
+  issuedAt,
+  jwtId,
+}) {
+  const token = createAmoJwt({ issuer, secret, issuedAt, jwtId });
+  let response;
+
+  try {
+    response = await fetchImpl(buildAmoEndpoint(addonId, apiBase), {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        Authorization: `JWT ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `AMO metadata request failed: ${redact(message, [
+        issuer,
+        secret,
+        token,
+      ])}`,
+    );
+  }
+
+  if (!response.ok) {
+    let responseBody;
+    try {
+      responseBody = await response.text();
+    } catch {
+      responseBody = "response body could not be read";
+    }
+    const detail = redact(responseBody, [issuer, secret, token]).slice(
+      0,
+      2_000,
+    );
+    throw new Error(
+      `AMO metadata update failed with HTTP ${response.status}${
+        detail ? `: ${detail}` : ""
+      }`,
+    );
+  }
+
+  return response.status;
+}
+
+function printUsage() {
+  console.log(
+    "Usage: node scripts/publish-firefox-metadata.mjs [--apply]\n\n" +
+      "Without --apply, prints the exact validated AMO PATCH payload and does not require credentials.",
+  );
+}
+
+export async function runCli({
+  args = process.argv.slice(2),
+  environment = process.env,
+} = {}) {
+  if (args.length === 1 && args[0] === "--help") {
+    printUsage();
+    return;
+  }
+  if (args.length > 1 || (args.length === 1 && args[0] !== "--apply")) {
+    throw new Error(
+      "Usage: node scripts/publish-firefox-metadata.mjs [--apply]",
+    );
+  }
+
+  const payload = loadAmoMetadataPayload();
+  if (args.length === 0) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+
+  const credentials = requireAmoCredentials(environment);
+  const status = await publishAmoMetadata({ payload, ...credentials });
+  console.log(`Firefox listing metadata published to AMO (HTTP ${status}).`);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  runCli().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/store-listing/README.md
+++ b/store-listing/README.md
@@ -137,16 +137,21 @@ FIREFOX_ADDON_ID=... \
 npm run store:publish:firefox-metadata -- --apply
 ```
 
+The manually dispatched `publish-firefox-metadata` Actions workflow also
+defaults to dry-run. Its apply mode only runs from the repository default branch
+and requires typing `PUBLISH FIREFOX METADATA`; only the apply job receives the
+existing Firefox secrets. This workflow is intentionally separate from release
+publishing because Chrome and Edge listing updates remain manual.
+
+**Translation review before production:** the eight non-English detailed
+descriptions and search-term sets are high-quality drafts, but they have not had
+native-speaker review. Native review is recommended before using either the
+apply command/workflow or entering this copy in any store dashboard.
+
 The publisher creates a short-lived HS256 JWT, URL-encodes the add-on ID, and
 sends one authenticated `PATCH` to
 `https://addons.mozilla.org/api/v5/addons/addon/{id}/`. It fails on any non-2xx
 response and redacts credentials and tokens from reported errors.
-
-The manually dispatched `publish-firefox-metadata` Actions workflow also
-defaults to dry-run. Its apply mode requires typing `PUBLISH FIREFOX METADATA`;
-only the apply job receives the existing Firefox secrets. This workflow is
-intentionally separate from release publishing because Chrome and Edge listing
-updates remain manual.
 
 ## Complete the Firefox listing in the dashboard
 

--- a/store-listing/README.md
+++ b/store-listing/README.md
@@ -1,8 +1,8 @@
 # Store listing metadata
 
 [`metadata.json`](metadata.json) is the source of truth for content managed in
-the Chrome Web Store, Microsoft Edge Add-ons, and Firefox Add-ons dashboards.
-It owns:
+the Chrome Web Store, Microsoft Edge Add-ons, and Firefox Add-ons listings. It
+owns:
 
 - the shared website, support, and privacy URLs;
 - the Chrome category;
@@ -15,7 +15,7 @@ metadata file. They resolve from `extName` and `extDescription` in
 `src/_locales/*/messages.json`, as referenced by `src/manifest.json`. This keeps
 all 55 package summaries in one place.
 
-Run the validator before editing a dashboard:
+Run the validator before publishing metadata or editing a dashboard:
 
 ```sh
 npm run store:validate
@@ -108,43 +108,83 @@ term, and maximum of 21 words across all terms.
 Official reference:
 [Publish a Microsoft Edge extension](https://learn.microsoft.com/en-us/microsoft-edge/extensions/publish/publish-extension).
 
-## Apply to Firefox Add-ons
+## Publish supported Firefox Add-ons fields
+
+AMO's authenticated v5 Edit endpoint supports the localized name, summary,
+description, and homepage plus global tags. The dependency-free publisher
+validates all canonical metadata before building that exact payload. It does not
+upload an extension package or include categories, screenshots, support URL, or
+privacy policy.
+
+Dry-run is the default and does not require credentials:
+
+```sh
+npm run --silent store:publish:firefox-metadata
+```
+
+The command prints the exact JSON `PATCH` payload. Repository locales map to AMO
+as follows: `en` → `en-US`, `de` → `de`, `es` → `es`, `fr` → `fr`, `ja` →
+`ja`, `pt_BR` → `pt-BR`, `zh_CN` → `zh-CN`, `zh_TW` → `zh-TW`, and `ko` →
+`ko`.
+
+Publishing requires an explicit flag and the same account-wide AMO credentials
+already used for Firefox package publishing:
+
+```sh
+FIREFOX_JWT_ISSUER=... \
+FIREFOX_JWT_SECRET=... \
+FIREFOX_ADDON_ID=... \
+npm run store:publish:firefox-metadata -- --apply
+```
+
+The publisher creates a short-lived HS256 JWT, URL-encodes the add-on ID, and
+sends one authenticated `PATCH` to
+`https://addons.mozilla.org/api/v5/addons/addon/{id}/`. It fails on any non-2xx
+response and redacts credentials and tokens from reported errors.
+
+The manually dispatched `publish-firefox-metadata` Actions workflow also
+defaults to dry-run. Its apply mode requires typing `PUBLISH FIREFOX METADATA`;
+only the apply job receives the existing Firefox secrets. This workflow is
+intentionally separate from release publishing because Chrome and Edge listing
+updates remain manual.
+
+## Complete the Firefox listing in the dashboard
 
 1. Run `npm run store:validate`, then open Mortality in the
    [Add-ons Developer Hub](https://addons.mozilla.org/developers/).
-2. Open the add-on's product-page editor. For each priority locale, keep the
-   name as `Mortality`, copy **PACKAGE SUMMARY** to the localized summary, and
-   copy **FULL DESCRIPTION** to the localized description.
-3. Set **Homepage** to the canonical website, **Support site** to the canonical
-   support URL, and **Privacy policy** to the canonical privacy URL.
-4. Set the global tags to the **FIREFOX TAGS (GLOBAL)** values printed by
-   `store:show`. AMO tags are simple unlocalized strings, so do not translate
-   them per locale.
-5. Save the product-page changes and inspect the public localized pages.
+2. Publish the API-supported fields with the command or manual workflow above,
+   then inspect the localized name, summary, description, homepage, and global
+   tags on the product-page editor.
+3. Set **Support site** to the canonical support URL and **Privacy policy** to
+   the canonical privacy URL. AMO's documented Edit payload does not expose
+   either field, so these remain dashboard updates.
+4. Save any dashboard changes and inspect the public localized pages.
 
 Official references:
 [Create an appealing listing](https://extensionworkshop.com/documentation/develop/create-an-appealing-listing/)
 and [AMO tag API](https://mozilla.github.io/addons-server/topics/api/tags.html).
 
-## Why listing updates remain manual
+## Automation boundaries
 
-The release workflow remains responsible only for immutable extension
-packages:
+Chrome and Edge listing metadata remains manual:
 
 - Chrome Web Store API v2 uploads, checks, and publishes package revisions.
   Google notes that additional metadata still has to be supplied in the
   Developer Dashboard.
 - The Edge Update REST API explicitly has no endpoint for product metadata such
   as descriptions; those edits require Partner Center.
-- AMO documents an authenticated add-on metadata `PATCH`, but also states that
-  the API is not frozen and may change without warning. Its API key can act on
-  behalf of the developer account, and the documented edit payload does not
-  cover every required support/privacy field.
 
-Adding partial AMO-only automation would therefore expand secret scope while
-leaving the other stores and some AMO fields manual. Keep
-`.github/workflows/publish.yml` and `scripts/publish.sh` package-only, and apply
-this metadata through the dashboards.
+AMO documents the authenticated metadata `PATCH` used by this tool, but the v5
+API is not frozen and may change without warning. AMO API credentials act on
+behalf of the developer account; this repository already stores the same
+account-wide issuer and secret for package publishing, so the metadata tool does
+not add credentials or expand secret availability. It does add another
+explicit, manual use of those credentials.
+
+Keep `.github/workflows/publish.yml` and `scripts/publish.sh` package-only.
+Firefox support and privacy URLs remain manual, and AMO metadata publishing must
+not be added to the automatic release path while the equivalent Chrome and Edge
+updates require dashboards.
 
 Official API references:
 [Chrome Web Store API v2](https://developer.chrome.com/blog/cws-api-v2),

--- a/test/publish-firefox-metadata.test.js
+++ b/test/publish-firefox-metadata.test.js
@@ -9,6 +9,7 @@ import {
   createAmoJwt,
   loadAmoMetadataPayload,
   publishAmoMetadata,
+  requireAmoCredentials,
   validateAndBuildAmoPayload,
 } from "../scripts/publish-firefox-metadata.mjs";
 import {
@@ -122,6 +123,20 @@ describe("Firefox listing metadata payload", () => {
     expect(result.stderr).toContain(
       "--apply requires the following environment variables: FIREFOX_JWT_ISSUER, FIREFOX_JWT_SECRET, FIREFOX_ADDON_ID",
     );
+  });
+
+  it("trims validated credentials before using them", () => {
+    expect(
+      requireAmoCredentials({
+        FIREFOX_JWT_ISSUER: "  user:123:456\n",
+        FIREFOX_JWT_SECRET: "\tapi-secret  ",
+        FIREFOX_ADDON_ID: " mortality@example.com\n",
+      }),
+    ).toEqual({
+      issuer: "user:123:456",
+      secret: "api-secret",
+      addonId: "mortality@example.com",
+    });
   });
 });
 

--- a/test/publish-firefox-metadata.test.js
+++ b/test/publish-firefox-metadata.test.js
@@ -1,0 +1,232 @@
+import { createHmac } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildAmoEndpoint,
+  createAmoJwt,
+  loadAmoMetadataPayload,
+  publishAmoMetadata,
+  validateAndBuildAmoPayload,
+} from "../scripts/publish-firefox-metadata.mjs";
+import {
+  loadStoreMetadata,
+  renderFullDescription,
+  validateStoreMetadata,
+} from "../scripts/validate-store-metadata.mjs";
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const SCRIPT = join(ROOT, "scripts", "publish-firefox-metadata.mjs");
+const metadata = loadStoreMetadata(ROOT);
+const validation = validateStoreMetadata(metadata, { root: ROOT });
+const expectedAmoLocales = [
+  "en-US",
+  "de",
+  "es",
+  "fr",
+  "ja",
+  "pt-BR",
+  "zh-CN",
+  "zh-TW",
+  "ko",
+];
+
+function environmentWithoutFirefoxCredentials() {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([name]) => !name.startsWith("FIREFOX_"),
+    ),
+  );
+}
+
+function decodeJson(segment) {
+  return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+}
+
+describe("Firefox listing metadata payload", () => {
+  it("contains only officially writable fields with the exact canonical copy", () => {
+    const payload = loadAmoMetadataPayload(ROOT);
+
+    expect(Object.keys(payload)).toEqual([
+      "name",
+      "summary",
+      "description",
+      "homepage",
+      "tags",
+    ]);
+    expect(payload.tags).toEqual(metadata.firefox.tags);
+
+    for (const [repositoryLocale, localeMetadata] of Object.entries(
+      metadata.locales,
+    )) {
+      const amoLocale = localeMetadata.storeLocales.firefox;
+      expect(payload.name[amoLocale]).toBe(metadata.productName);
+      expect(payload.summary[amoLocale]).toBe(
+        validation.summaries[repositoryLocale],
+      );
+      expect(payload.description[amoLocale]).toBe(
+        renderFullDescription(localeMetadata),
+      );
+      expect(payload.homepage[amoLocale]).toBe(metadata.urls.website);
+    }
+
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain(metadata.urls.support);
+    expect(serialized).not.toContain(metadata.urls.privacy);
+  });
+
+  it("maps repository locales to the expected AMO locale codes", () => {
+    const payload = loadAmoMetadataPayload(ROOT);
+
+    for (const field of ["name", "summary", "description", "homepage"]) {
+      expect(Object.keys(payload[field])).toEqual(expectedAmoLocales);
+    }
+  });
+
+  it("blocks publishing when canonical metadata is malformed", () => {
+    const invalid = structuredClone(metadata);
+    delete invalid.locales.fr.storeLocales.firefox;
+
+    expect(() => validateAndBuildAmoPayload(invalid, { root: ROOT })).toThrow(
+      'Store metadata validation failed:\n- metadata.locales.fr.storeLocales is missing "firefox"',
+    );
+  });
+
+  it("prints the exact payload in dry-run mode without credentials", () => {
+    const result = spawnSync(process.execPath, [SCRIPT], {
+      cwd: ROOT,
+      env: environmentWithoutFirefoxCredentials(),
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toEqual(loadAmoMetadataPayload(ROOT));
+  });
+
+  it("requires all existing Firefox credentials when applying", () => {
+    const result = spawnSync(process.execPath, [SCRIPT, "--apply"], {
+      cwd: ROOT,
+      env: environmentWithoutFirefoxCredentials(),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(
+      "--apply requires the following environment variables: FIREFOX_JWT_ISSUER, FIREFOX_JWT_SECRET, FIREFOX_ADDON_ID",
+    );
+  });
+});
+
+describe("AMO authentication and request safety", () => {
+  it("creates a short-lived, correctly signed HS256 JWT", () => {
+    const issuer = "user:123:456";
+    const secret = "test-api-secret";
+    const token = createAmoJwt({
+      issuer,
+      secret,
+      issuedAt: 1_700_000_000,
+      jwtId: "unique-jwt-id",
+    });
+    const [encodedHeader, encodedClaims, signature] = token.split(".");
+    const signingInput = `${encodedHeader}.${encodedClaims}`;
+
+    expect(decodeJson(encodedHeader)).toEqual({ alg: "HS256", typ: "JWT" });
+    expect(decodeJson(encodedClaims)).toEqual({
+      iss: issuer,
+      jti: "unique-jwt-id",
+      iat: 1_700_000_000,
+      exp: 1_700_000_060,
+    });
+    expect(signature).toBe(
+      createHmac("sha256", secret).update(signingInput).digest("base64url"),
+    );
+  });
+
+  it("URL-encodes the add-on identifier and sends the exact PATCH body", async () => {
+    const payload = loadAmoMetadataPayload(ROOT);
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      text: async () => "",
+    });
+    const addonId = "mortality/test@example.com?channel=listed";
+
+    await expect(
+      publishAmoMetadata({
+        payload,
+        issuer: "issuer",
+        secret: "secret",
+        addonId,
+        fetchImpl,
+        issuedAt: 1_700_000_000,
+        jwtId: "request-id",
+      }),
+    ).resolves.toBe(204);
+
+    expect(buildAmoEndpoint(addonId)).toBe(
+      "https://addons.mozilla.org/api/v5/addons/addon/mortality%2Ftest%40example.com%3Fchannel%3Dlisted/",
+    );
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, request] = fetchImpl.mock.calls[0];
+    expect(url).toBe(buildAmoEndpoint(addonId));
+    expect(request.method).toBe("PATCH");
+    expect(request.headers.Accept).toBe("application/json");
+    expect(request.headers["Content-Type"]).toBe("application/json");
+    expect(request.headers.Authorization).toMatch(/^JWT [^.]+\.[^.]+\.[^.]+$/u);
+    expect(JSON.parse(request.body)).toEqual(payload);
+  });
+
+  it("fails loudly on HTTP errors while redacting credentials and tokens", async () => {
+    const issuer = "sensitive-issuer";
+    const secret = "sensitive-secret";
+    const fetchImpl = vi.fn(async (_url, request) => ({
+      ok: false,
+      status: 403,
+      text: async () =>
+        `denied issuer=${issuer} secret=${secret} auth=${request.headers.Authorization}`,
+    }));
+
+    let failure;
+    try {
+      await publishAmoMetadata({
+        payload: loadAmoMetadataPayload(ROOT),
+        issuer,
+        secret,
+        addonId: "mortality@example.com",
+        fetchImpl,
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect(failure.message).toContain(
+      "AMO metadata update failed with HTTP 403",
+    );
+    expect(failure.message).toContain("[REDACTED]");
+    expect(failure.message).not.toContain(issuer);
+    expect(failure.message).not.toContain(secret);
+    const token = fetchImpl.mock.calls[0][1].headers.Authorization.slice(4);
+    expect(failure.message).not.toContain(token);
+  });
+
+  it("redacts credentials from transport failures", async () => {
+    const secret = "transport-secret";
+    const fetchImpl = vi
+      .fn()
+      .mockRejectedValue(new Error(`failure: ${secret}`));
+
+    await expect(
+      publishAmoMetadata({
+        payload: loadAmoMetadataPayload(ROOT),
+        issuer: "issuer",
+        secret,
+        addonId: "mortality@example.com",
+        fetchImpl,
+      }),
+    ).rejects.toThrow("AMO metadata request failed: failure: [REDACTED]");
+  });
+});

--- a/test/publish-firefox-metadata.test.js
+++ b/test/publish-firefox-metadata.test.js
@@ -1,5 +1,6 @@
 import { createHmac } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
@@ -18,6 +19,10 @@ import {
 
 const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const SCRIPT = join(ROOT, "scripts", "publish-firefox-metadata.mjs");
+const WORKFLOW = readFileSync(
+  join(ROOT, ".github", "workflows", "publish-firefox-metadata.yml"),
+  "utf8",
+);
 const metadata = loadStoreMetadata(ROOT);
 const validation = validateStoreMetadata(metadata, { root: ROOT });
 const expectedAmoLocales = [
@@ -228,5 +233,30 @@ describe("AMO authentication and request safety", () => {
         fetchImpl,
       }),
     ).rejects.toThrow("AMO metadata request failed: failure: [REDACTED]");
+  });
+});
+
+describe("Firefox metadata workflow safety", () => {
+  it("keeps dry-run ref-independent and blocks apply outside the default branch", () => {
+    const dryRunJob = WORKFLOW.slice(
+      WORKFLOW.indexOf("  dry-run:\n"),
+      WORKFLOW.indexOf("  apply:\n"),
+    );
+    const applyJob = WORKFLOW.slice(WORKFLOW.indexOf("  apply:\n"));
+
+    expect(dryRunJob).not.toContain("github.ref_name");
+    expect(dryRunJob).not.toContain("default_branch");
+    expect(dryRunJob).not.toContain("secrets.FIREFOX_");
+
+    expect(applyJob).toContain("SELECTED_REF: ${{ github.ref_name }}");
+    expect(applyJob).toContain(
+      "DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}",
+    );
+    expect(applyJob).toContain(
+      'if [ "$SELECTED_REF" != "$DEFAULT_BRANCH" ]; then',
+    );
+    expect(
+      applyJob.indexOf("github.event.repository.default_branch"),
+    ).toBeLessThan(applyJob.indexOf("secrets.FIREFOX_JWT_ISSUER"));
   });
 });


### PR DESCRIPTION
## Summary

- add a dependency-free, dry-run-first Node CLI that validates canonical store metadata and builds AMO's supported localized listing payload
- require `--apply` plus the existing Firefox issuer, secret, and add-on ID; generate a short-lived HS256 JWT and redact credentials from failures
- add an isolated manual workflow whose dry-run receives no secrets and whose apply mode requires typed confirmation
- document that Chrome/Edge and Firefox support/privacy fields remain dashboard-only

## Safety boundary

The PATCH contains only localized `name`, `summary`, `description`, and `homepage`, plus global `tags`. It does not touch packages, categories, screenshots, support URL, privacy policy, or automatic release publishing.

## Tests

- `npm test`
- `npm run format:check`
- `npm run zip`
