### PR TITLE
Polish README masthead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-<h1>
-  <img src="./store-assets/final/icon-64.png" alt="" width="36" height="36" align="absmiddle" />
-  Mortality
-</h1>
+<p>
+  <img src="./store-assets/final/icon-64.png" alt="" width="48" height="48" />
+</p>
+
+# Mortality
 
 A browser extension that replaces your new tab page with a live counter of your age — a quiet, recurring reminder that time is passing.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-<p>
-  <img src="./store-assets/final/icon-64.png" alt="" width="48" height="48" />
-</p>
-
-# Mortality
-
-A browser extension that replaces your new tab page with a live counter of your age — a quiet, recurring reminder that time is passing.
-
-[**Try Mortality online**](https://alphabt.github.io/mortality/)
+<div align="center">
+  <img src="./store-assets/final/icon-64.png" alt="" width="64" height="64" />
+  <h1>Mortality</h1>
+  <p>
+    Your age, counting up live on every new tab.<br />
+    A quiet, recurring reminder that time is passing.
+  </p>
+  <p><a href="https://alphabt.github.io/mortality/"><strong>Try Mortality online</strong></a></p>
+</div>
 
 The online demo saves settings in this browser's local storage. Install the extension
 from a browser store below to use Mortality as your new tab page.

--- a/store-assets/README.md
+++ b/store-assets/README.md
@@ -7,11 +7,11 @@ the screenshots are generated from the unmodified v1.6.0 UI by
 
 ## Store icons
 
-| File                 | Dimensions     | Use                                 |
-| -------------------- | -------------- | ----------------------------------- |
-| `source/icon.svg`    | 128x128 vector | Editable icon master                |
-| `final/icon-64.png`  | 64x64          | Small listing and README title icon |
-| `final/icon-300.png` | 300x300        | Large listing icon                  |
+| File                 | Dimensions     | Use                                  |
+| -------------------- | -------------- | ------------------------------------ |
+| `source/icon.svg`    | 128x128 vector | Editable icon master                 |
+| `final/icon-64.png`  | 64x64          | Small listing and README header mark |
+| `final/icon-300.png` | 300x300        | Large listing icon                   |
 
 ## Dashboard upload order
 


### PR DESCRIPTION
## Summary
- move the Mortality icon out of the title line and present it as a centered 64px standalone mark
- tighten the introduction into two calm, factual lines with one live-demo action
- describe the shared 64px asset as the README header mark

## Visual direction
The masthead is treated like a quiet watch face: one precise mark, one title, a short reading, and a single action. The existing GitHub H1 hairline becomes the instrument baseline; there are no cards, badges, shadows, gradients, or extra decorative elements.

## Validation
- `npx vitest run test/privacy.test.js`
- `npm run format:check`
- impeccable design detector on `README.md` and `store-assets/README.md`