### PR TITLE
Normalize GitHub Actions workflow names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "ci"
+name: "CI"
 
 # The quality gate. Runs on every pull request, and is reused (workflow_call) by
 # pre-release.yml and release.yml so nothing is packaged, released, or published

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,4 @@
-name: "pages"
+name: "Pages"
 
 on:
   push:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,4 +1,4 @@
-name: "pre-release"
+name: "Pre-release"
 
 # Rolling development build. Every push to main runs the full quality gate and,
 # if green, refreshes the single "latest" pre-release with the freshly packaged

--- a/.github/workflows/publish-firefox-metadata.yml
+++ b/.github/workflows/publish-firefox-metadata.yml
@@ -1,4 +1,4 @@
-name: "publish-firefox-metadata"
+name: "Publish Firefox Metadata"
 
 # Listing metadata stays separate from release/package publishing so an AMO
 # update cannot silently drift ahead of the manual Chrome and Edge listings.

--- a/.github/workflows/publish-stores.yml
+++ b/.github/workflows/publish-stores.yml
@@ -1,4 +1,4 @@
-name: "publish-stores"
+name: "Publish Stores"
 
 # Manual store publishing: re-publish a released tag, ship a subset of stores,
 # or recover a single store that failed mid-release. It only accepts an existing

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: "publish"
+name: "Publish"
 
 # Reusable store-publish engine. Each store runs in an isolated job that receives
 # only that store's credentials. Both release.yml and publish-stores.yml call it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: "release"
+name: "Release"
 
 # The automatic release pipeline. Pushing a v* tag runs the full quality gate,
 # packages the extension exactly once, publishes a GitHub Release, then ships that


### PR DESCRIPTION
Repository-owned workflows currently appear as lowercase, filename-style identifiers in the Actions sidebar, unlike GitHub-provided workflows. This updates only their top-level display names to readable casing, preserving acronyms and brands such as `CI` and `Firefox` without changing filenames or workflow behavior.