### PR TITLE
Release v1.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mortality",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mortality",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mortality",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "description": "A browser extension that replaces the new tab page with a live counter of your age.",
   "license": "MIT",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
   "permissions": ["storage"],


### PR DESCRIPTION
## Summary

- bump the extension manifest, package metadata, and lockfile to 1.6.1
- prepare the tag-driven release workflow to package once and submit the same artifact to Chrome, Edge, and Firefox

## Release

After this PR merges, tag the merge commit as `v1.6.1` to run the automatic release pipeline.