### PR TITLE
ci: auto-merge Dependabot dev-dependency updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,58 @@
+name: "Dependabot auto-merge"
+
+# Routine toolchain bumps shouldn't cost a review. Nothing in package.json ships —
+# the extension has no runtime dependencies, so devDependencies are only build and
+# test tooling — which makes a green CI run the whole signal for a vitest, prettier,
+# or playwright bump. This just switches on GitHub's auto-merge; the branch ruleset
+# still holds the PR until Prettier, Vitest, and Pack pass, so nothing lands
+# unverified. Major bumps and anything touching a production dependency are left
+# alone on purpose: those deserve a human reading the changelog.
+#
+# Dependabot's own `pull_request` runs get a read-only token, which cannot enable
+# auto-merge, hence `pull_request_target` — it runs from the base branch with a
+# writable token. That token must never meet untrusted code, so this workflow does
+# not check the PR out, installs nothing, and runs no repo scripts. Testing the
+# proposed code is ci.yml's job, and that runs in the ordinary read-only
+# `pull_request` context.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: "Enable auto-merge"
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+
+      # Both dependabot.yml ecosystems are grouped, so a PR usually carries several
+      # updates. These outputs report the worst case across the group — the highest
+      # semver bump and the most production-facing dependency type — so one major or
+      # one production dependency anywhere in the group sends the whole PR to a human.
+      #
+      # `indirect` is safe to include because this repo declares no production
+      # dependencies at all: a transitive bump can only come from the dev toolchain.
+      # `package-ecosystem` is read off the branch name, so the Actions ecosystem
+      # reports as `github_actions` rather than the `github-actions` spelling used in
+      # dependabot.yml. It needs its own clause because Dependabot labels actions as
+      # production dependencies.
+      - name: Enable auto-merge
+        if: >-
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          (steps.metadata.outputs.dependency-type == 'direct:development' ||
+          steps.metadata.outputs.dependency-type == 'indirect' ||
+          steps.metadata.outputs.package-ecosystem == 'github_actions')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,15 +8,15 @@ name: "Dependabot auto-merge"
 # unverified. Major bumps and anything touching a production dependency are left
 # alone on purpose: those deserve a human reading the changelog.
 #
-# Dependabot's own `pull_request` runs get a read-only token, which cannot enable
-# auto-merge, hence `pull_request_target` — it runs from the base branch with a
-# writable token. That token must never meet untrusted code, so this workflow does
-# not check the PR out, installs nothing, and runs no repo scripts. Testing the
-# proposed code is ci.yml's job, and that runs in the ordinary read-only
-# `pull_request` context.
+# Dependabot-triggered runs get a read-only `GITHUB_TOKEN` by default, which cannot
+# enable auto-merge; the `permissions` block below raises it to the `contents: write`
+# and `pull-requests: write` this needs. That is the whole reason it is spelled out,
+# and it is why plain `pull_request` suffices — no privileged `pull_request_target`
+# run against an untrusted head. This workflow checks nothing out, installs nothing,
+# and runs no repo scripts either way; testing the proposed code is ci.yml's job.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
 
@@ -33,6 +33,8 @@ jobs:
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       # Both dependabot.yml ecosystems are grouped, so a PR usually carries several
       # updates. These outputs report the worst case across the group — the highest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,7 +28,15 @@ jobs:
   auto-merge:
     name: "Enable auto-merge"
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
+    # Both actor and author must be Dependabot, the head branch must live in this
+    # repo rather than a fork, and the PR must not be a draft — GitHub refuses
+    # auto-merge on a draft, and the `ready_for_review` trigger above brings the PR
+    # back here the moment that changes.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
     steps:
       - name: Fetch Dependabot metadata
         id: metadata


### PR DESCRIPTION
Adds `.github/workflows/dependabot-auto-merge.yml` so routine dependency bumps stop needing a hand-review. Nothing in `package.json` ships — the extension has no runtime dependencies, so everything in `devDependencies` is build/test tooling — which makes a green CI run the entire signal for a bump like #92 (playwright 1.62.0 → 1.62.1, web-ext 10.5.0 → 10.6.0).

The workflow only turns on GitHub's auto-merge. It never merges anything itself: the branch ruleset still holds the PR until Prettier, Vitest, and Pack pass.

### What auto-merges

A Dependabot PR against `main` where **both** hold:

- `update-type` is `version-update:semver-patch` or `version-update:semver-minor`, **and**
- `dependency-type` is `direct:development` or `indirect`, **or** the ecosystem is `github_actions`.

Both of this repo's Dependabot configs are grouped, so a PR usually carries several updates. `dependabot/fetch-metadata` reports the *worst case* across a group — the highest semver bump and the most production-facing dependency type — so a single major, or a single production dependency anywhere in the group, fails the check and the whole PR waits. `indirect` is included because this repo declares no production dependencies at all, so a transitive bump can only come from the dev toolchain. Actions get their own clause because Dependabot labels them as production dependencies.

### What still requires a human

- Any major bump, including `actions/checkout@v7 → v8`-style ones.
- Anything reported as `direct:production` — which today can only happen if the extension ever gains a real runtime dependency.
- Anything not authored by `dependabot[bot]`.

### Security shape

Dependabot-triggered runs get a read-only `GITHUB_TOKEN` by default, which can't enable auto-merge. The explicit `permissions: { contents: write, pull-requests: write }` block raises it to what's needed — that's the documented fix, and it's what GitHub's own auto-merge example does on a plain `on: pull_request` trigger.

An earlier revision of this PR used `pull_request_target`. It didn't need to, and it was worse: `pull_request_target` runs privileged in base-branch context, which would make "this workflow must never check out the PR" a load-bearing invariant enforced only by a comment. A future maintainer adding an innocuous `actions/checkout` step would turn it into an RCE vector against a `contents: write` token. On `pull_request` that failure mode is structurally impossible, and for Dependabot PRs there's no behavioral difference — the branch is cut from `main`, so the workflow file that runs is identical either way.

Either way the workflow checks nothing out, installs nothing, and runs no repo scripts; the only step touching the PR is `gh pr merge --auto --squash`. Testing the proposed code stays with `ci.yml` (confirmed running on Dependabot PRs — #92 has passing Prettier / Vitest / Chromium / Pack runs).

`GITHUB_TOKEN`-initiated merges don't re-trigger workflows, but that's irrelevant here: auto-merge waits on the CI run that Dependabot's own push already started.

### Known limitation: Copilot review threads can stall auto-merge

The "Require resolved feedback and checks" ruleset sets `required_review_thread_resolution: true` and runs `copilot_code_review` on push, with an empty bypass-actor list. If Copilot opens a review thread on a Dependabot PR, GitHub auto-merge will sit there until someone resolves it — auto-merge respects every ruleset requirement, and thread resolution is one.

I deliberately did **not** touch the ruleset. Possible follow-ups if this turns out to bite in practice:

- Exclude Dependabot-authored PRs from Copilot code review.
- Add a narrowly-scoped bypass actor for the review-thread-resolution requirement.
- Leave it as-is and resolve the occasional thread by hand — still cheaper than reviewing every lockfile bump.

### Notes

- Uses `dependabot/fetch-metadata@v3`, not `v2`. v3 is the current major (v3.1.0); its only breaking change is requiring the Node 24 Actions runtime. This matches the repo's convention of pinning latest major tags, and avoids Dependabot immediately opening a v2 → v3 PR.
- `package-ecosystem` is matched as `github_actions` (underscore), not the `github-actions` spelling used in `dependabot.yml` — the action derives that output from the branch name (`dependabot/github_actions/actions-…`). Verified against #89.
- `dependency-type` is matched as `indirect`; `indirect:development` isn't a value the action emits.
- No change needed to `.github/dependabot.yml`.

### Validation

- `npm run format:check` — clean.
- `npm test` — 496 tests across 16 files, all passing.
- Workflow YAML parses; trigger, `permissions`, job `if`, and step `if` verified against the parsed tree.
- No changes to `package.json`, `package-lock.json`, or `src/`.
- The workflow can't actually be exercised until it's on `main`, so correctness review is the only gate available here.
